### PR TITLE
Feat : DIG-8 GlobalException 구축

### DIFF
--- a/src/main/java/com/ogjg/daitgym/common/exception/controller/ExceptionControllerAdvice.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/controller/ExceptionControllerAdvice.java
@@ -1,0 +1,42 @@
+package com.ogjg.daitgym.common.exception.controller;
+
+import com.ogjg.daitgym.common.exception.exception.CustomException;
+import com.ogjg.daitgym.common.exception.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.response.ApiResponse;
+import com.ogjg.daitgym.common.exception.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ControllerAdvice
+public class ExceptionControllerAdvice {
+
+    @ExceptionHandler(CustomException.class)
+    @ResponseBody
+    public ApiResponse<?> customExceptionHandler(
+            HttpServletResponse response, CustomException e
+    ) {
+        response.setStatus(e.getErrorCode().getStatusCode().value());
+        return new ErrorResponse(e.getErrorCode(), e.getErrorData());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseBody
+    public ApiResponse<?> validationHandler(
+            HttpServletResponse response, MethodArgumentNotValidException e
+    ) {
+        response.setStatus(ErrorCode.INVALID_FORMAT.getStatusCode().value());
+        String errorMessage = validationErrorMessage(e.getBindingResult().getFieldError());
+        return new ErrorResponse(ErrorCode.INVALID_FORMAT.changeMessage(errorMessage));
+    }
+
+    private String validationErrorMessage(FieldError fieldError) {
+        if (fieldError != null) {
+            return fieldError.getDefaultMessage();
+        }
+        return ErrorCode.INVALID_FORMAT.getMessage();
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/exception/CustomException.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/exception/CustomException.java
@@ -1,0 +1,34 @@
+package com.ogjg.daitgym.common.exception.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class CustomException extends RuntimeException {
+
+    private final ErrorType errorCode;
+    private ErrorData errorData;
+
+    public CustomException(
+            ErrorCode errorCode
+    ) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(
+            ErrorCode errorCode,
+            String message
+    ) {
+        super(errorCode.changeMessage(message).getMessage());
+        this.errorCode = errorCode.changeMessage(message);
+    }
+
+    public CustomException(
+            ErrorCode errorCode,
+            ErrorData errorData
+    ) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.errorData = errorData;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorCode.java
@@ -1,0 +1,36 @@
+package com.ogjg.daitgym.common.exception.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode implements ErrorType {
+
+    SUCCESS(HttpStatus.OK, "200", "OK"),
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터 검증 실패"),
+    ;
+
+    @JsonIgnore
+    private final HttpStatus statusCode;
+    private final String code;
+    private String message;
+
+    ErrorCode(
+            HttpStatus statusCode,
+            String code,
+            String message
+    ) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    public ErrorResult changeMessage(
+            String message
+    ) {
+        return new ErrorResult(this.statusCode, this.getCode(), message);
+    }
+
+
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorData.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorData.java
@@ -1,0 +1,4 @@
+package com.ogjg.daitgym.common.exception.exception;
+
+public interface ErrorData {
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorResult.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorResult.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.common.exception.exception;
+
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ErrorResult implements ErrorType {
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    public ErrorResult(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorType.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/exception/ErrorType.java
@@ -1,0 +1,13 @@
+package com.ogjg.daitgym.common.exception.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorType {
+
+    HttpStatus getStatusCode();
+
+    String getCode();
+
+    String getMessage();
+
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/response/ApiResponse.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/response/ApiResponse.java
@@ -1,0 +1,22 @@
+package com.ogjg.daitgym.common.exception.response;
+
+import com.ogjg.daitgym.common.exception.exception.ErrorType;
+import com.ogjg.daitgym.common.exception.response.dto.Status;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private Status status;
+
+    private T data;
+
+    public ApiResponse(ErrorType errorCode) {
+        this.status = new Status(errorCode);
+    }
+
+    public ApiResponse(ErrorType errorCode, T data) {
+        this.status = new Status(errorCode);
+        this.data = data;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/response/ErrorResponse.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/response/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.ogjg.daitgym.common.exception.response;
+
+import com.ogjg.daitgym.common.exception.exception.ErrorData;
+import com.ogjg.daitgym.common.exception.exception.ErrorType;
+
+public class ErrorResponse extends ApiResponse<ErrorData> {
+
+    public ErrorResponse(ErrorType errorCode) {
+        super(errorCode);
+    }
+
+    public ErrorResponse(ErrorType errorCode, ErrorData errorData) {
+        super(errorCode, errorData);
+    }
+
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/response/dto/Status.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/response/dto/Status.java
@@ -1,0 +1,18 @@
+package com.ogjg.daitgym.common.exception.response.dto;
+
+
+import com.ogjg.daitgym.common.exception.exception.ErrorType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Status {
+    private String code;
+    private String message;
+
+    public Status(ErrorType errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+}


### PR DESCRIPTION
- CustomException 구축
- CustomException Handler 생성
- ValidationException Handler 생성

### ApiResponse : 모든 api 응답 모델에서 사용가능하게 Generic Type으로 정의

- 정상 api 응답 :
반환타입 : ApiResponse
return Type : new ApiResponse<>(ErrorCode, 응답보내줄 responseDto);
- Error 발생 :
반환타입 : ApiResponse
return Type : ErrorResponse(ErrorCode, ErrorData)

### ErrorData :
- Error 대한 상세내용이 더 필요하다면 객체를 생성하고 ErrorData 상속받아 사용
ErrorResponse의 생성자 파라미터에 Generic Type을 사용하지 않고, 
ErrorData 인터페이스로 타입을 제한하는게 안정성이 높다고 판단

### ErrorCode :
- 어떠한 에러들이 있는지 Enum Type으로 정의 message를 변경하고자 한다면 
ErrorCode.반환에러타입.changeMessage(바꿀내용)으로 메시지의 내용만 변경 가능
ErrorType은 Enum이라 message를 변경하면 영구히 변경되는 부분은 ErrorResult라는
객체를 통해 새로 생성해서 사용하는 시점의 메시지만  변경해서 사용할 수 있도록 설정

### CustomException :
- 도메인에서 Exception에 대한 정의가 필요하다면 CustomException 상속받아 정의

