### PR TITLE
Feat : DIG-41 운동일지 생성, 운동목록 추가, 운동기록 추가 구현

### DIFF
--- a/src/main/java/com/ogjg/daitgym/DaItGymApplication.java
+++ b/src/main/java/com/ogjg/daitgym/DaItGymApplication.java
@@ -2,12 +2,14 @@ package com.ogjg.daitgym;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DaItGymApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DaItGymApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(DaItGymApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/ogjg/daitgym/common/controller/ExceptionControllerAdvice.java
+++ b/src/main/java/com/ogjg/daitgym/common/controller/ExceptionControllerAdvice.java
@@ -5,12 +5,14 @@ import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
 import com.ogjg.daitgym.common.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+@Slf4j
 @ControllerAdvice
 public class ExceptionControllerAdvice {
 
@@ -20,6 +22,7 @@ public class ExceptionControllerAdvice {
             HttpServletResponse response, CustomException e
     ) {
         response.setStatus(e.getErrorCode().getStatusCode().value());
+        log.error(e.getMessage());
         return new ErrorResponse(e.getErrorCode(), e.getErrorData());
     }
 
@@ -30,6 +33,7 @@ public class ExceptionControllerAdvice {
     ) {
         response.setStatus(ErrorCode.INVALID_FORMAT.getStatusCode().value());
         String errorMessage = validationErrorMessage(e.getBindingResult().getFieldError());
+        log.error(errorMessage);
         return new ErrorResponse(ErrorCode.INVALID_FORMAT.changeMessage(errorMessage));
     }
 

--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -8,6 +8,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements ErrorType {
 
     SUCCESS(HttpStatus.OK, "200", "OK"),
+    NOT_FOUND_EXERCISE(HttpStatus.NOT_FOUND,"404","운동을 찾을 수 없습니다"),
+    NOT_FOUND_EXERCISE_LIST(HttpStatus.NOT_FOUND,"404","운동 목록을 찾을 수 없습니다"),
+    NOT_FOUND_JOURNAL(HttpStatus.NOT_FOUND,"404", "운동일지를 찾을 수 없습니다"),
+    USER_NOT_AUTHORIZED_JOURNAL(HttpStatus.FORBIDDEN,"403","운동일지에 접근 권한이 없습니다"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "404", "유저를 찾을 수 없습니다"),
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터 검증 실패"),
     NOT_FOUND_FEED_JOURNAL(HttpStatus.BAD_REQUEST,"400","운동일지 피드를 찾을 수 없습니다"),

--- a/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseHistory.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseHistory.java
@@ -1,7 +1,9 @@
 package com.ogjg.daitgym.domain.journal;
 
 import com.ogjg.daitgym.domain.BaseEntity;
+import com.ogjg.daitgym.journal.dto.request.ExerciseHistoryRequest;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,12 +25,32 @@ public class ExerciseHistory extends BaseEntity {
     @JoinColumn(name = "exercise_list_id")
     private ExerciseList exerciseList;
 
-    private int setCount;
+    private int setNum;
 
     private int weight;
 
-    private int repetition_count;
+    private int repetitionCount;
 
-    private boolean exercise_status;
+    private boolean isCompleted = false;
 
+    public static ExerciseHistory createExerciseHistory(ExerciseList exerciseList, ExerciseHistoryRequest exerciseHistoryRequest) {
+        return builder()
+                .exerciseList(exerciseList)
+                .setNum(exerciseHistoryRequest.getSetNum())
+                .weight(exerciseHistoryRequest.getWeight())
+                .repetitionCount(exerciseHistoryRequest.getRepetitionCount())
+                .build();
+    }
+
+    @Builder
+    public ExerciseHistory(
+            ExerciseList exerciseList, int setNum, int weight,
+            int repetitionCount, boolean isCompleted
+    ) {
+        this.exerciseList = exerciseList;
+        this.setNum = setNum;
+        this.weight = weight;
+        this.repetitionCount = repetitionCount;
+        this.isCompleted = isCompleted;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
@@ -4,6 +4,7 @@ import com.ogjg.daitgym.domain.BaseEntity;
 import com.ogjg.daitgym.domain.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,12 +28,12 @@ public class ExerciseJournal extends BaseEntity {
     @JoinColumn(name = "email")
     private User user;
 
-    private boolean journalVisibility = false;
+    private boolean isVisible = false;
 
-    private boolean exerciseStatus = false;
+    private boolean isCompleted = false;
 
     @NotNull
-    private LocalDate journalDate = LocalDate.now();
+    private LocalDate journalDate;
 
     private TimeTemplate exerciseTime;
 
@@ -42,8 +43,30 @@ public class ExerciseJournal extends BaseEntity {
 
     private String split;
 
-    public ExerciseJournal(User user) {
-        this.user = user;
+    public static ExerciseJournal createJournal(
+            User user, LocalDate journalDate
+    ) {
+        return builder()
+                .user(user)
+                .exerciseTime(new TimeTemplate())
+                .journalDate(journalDate)
+                .build();
     }
 
+    @Builder
+    public ExerciseJournal(
+            User user, boolean isVisible, boolean isCompleted,
+            LocalDate journalDate, TimeTemplate exerciseTime,
+            LocalDateTime exerciseStartTime, LocalDateTime exerciseEndTime,
+            String split
+    ) {
+        this.user = user;
+        this.isVisible = isVisible;
+        this.isCompleted = isCompleted;
+        this.journalDate = journalDate;
+        this.exerciseTime = exerciseTime;
+        this.exerciseStartTime = exerciseStartTime;
+        this.exerciseEndTime = exerciseEndTime;
+        this.split = split;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseList.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseList.java
@@ -2,8 +2,10 @@ package com.ogjg.daitgym.domain.journal;
 
 import com.ogjg.daitgym.domain.BaseEntity;
 import com.ogjg.daitgym.domain.Exercise;
+import com.ogjg.daitgym.journal.dto.request.ExerciseListRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,4 +38,24 @@ public class ExerciseList extends BaseEntity {
     @Embedded
     private TimeTemplate restTime;
 
+    public static ExerciseList createExercise(
+            ExerciseJournal exerciseJournal,
+            Exercise exercise,
+            ExerciseListRequest exerciseListRequest
+    ) {
+        return builder()
+                .exerciseJournal(exerciseJournal)
+                .exercise(exercise)
+                .exerciseNum(exerciseListRequest.getExerciseNum())
+                .restTime(new TimeTemplate(exerciseListRequest.getRestTime()))
+                .build();
+    }
+
+    @Builder
+    public ExerciseList(ExerciseJournal exerciseJournal, Exercise exercise, int exerciseNum, TimeTemplate restTime) {
+        this.exerciseJournal = exerciseJournal;
+        this.exercise = exercise;
+        this.exerciseNum = exerciseNum;
+        this.restTime = restTime;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/journal/TimeTemplate.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/TimeTemplate.java
@@ -2,7 +2,6 @@ package com.ogjg.daitgym.domain.journal;
 
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.Max;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,15 +13,14 @@ public class TimeTemplate {
     private int hour = 0;
 
     @Max(59)
-    private int minute = 0;
+    private int minutes = 0;
 
     @Max(59)
-    private int second = 0;
+    private int seconds = 0;
 
-    @Builder
-    public TimeTemplate(int hour, int minute, int second) {
-        this.hour = hour;
-        this.minute = minute;
-        this.second = second;
+    public TimeTemplate(TimeTemplate timeTemplate) {
+        this.hour = timeTemplate.getHour();
+        this.minutes = timeTemplate.getMinutes();
+        this.seconds = timeTemplate.getSeconds();
     }
 }

--- a/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
@@ -1,0 +1,68 @@
+package com.ogjg.daitgym.journal.controller;
+
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.journal.dto.request.CreateJournalRequest;
+import com.ogjg.daitgym.journal.dto.request.ExerciseHistoryRequest;
+import com.ogjg.daitgym.journal.dto.request.ExerciseListRequest;
+import com.ogjg.daitgym.journal.service.ExerciseJournalService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/journals")
+@RequiredArgsConstructor
+public class ExerciseJournalController {
+
+    private final ExerciseJournalService exerciseJournalService;
+
+    /**
+     * 빈 일지 생성하기
+     */
+    @PostMapping
+    public ApiResponse<Void> createJournal(
+//            todo 토큰에서 유저이메일 받아오기
+            String email,
+            @RequestBody CreateJournalRequest createJournalRequest
+    ) {
+        String email1 = "dlehdwls21@naver.com";
+        exerciseJournalService.createJournal(email1, createJournalRequest.getJournalDate());
+
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 일지에 운동 추가하기
+     */
+    @PostMapping("/exercise-list")
+    public ApiResponse<Void> addExerciseToJournal(
+//            todo 토큰에서 유저이메일 받아오기
+            String email,
+            @RequestBody ExerciseListRequest exerciseListRequest
+    ) {
+        String email1 = "dlehdwls21@naver.com";
+        exerciseJournalService.createExerciseList(email1, exerciseListRequest);
+
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 운동 목록에 운동기록 추가하기
+     */
+    @PostMapping("/exercise-history")
+    public ApiResponse<Void> addExerciseHistoryToExerciseList(
+//            todo 토큰에서 유저이메일 받아오기
+            String email,
+            @RequestBody ExerciseHistoryRequest exerciseHistoryRequest
+    ) {
+        String email1 = "dlehdwls21@naver.com";
+        exerciseJournalService.createExerciseHistory(email1, exerciseHistoryRequest);
+
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/CreateJournalRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/CreateJournalRequest.java
@@ -1,0 +1,15 @@
+package com.ogjg.daitgym.journal.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class CreateJournalRequest {
+
+    private LocalDate journalDate;
+}

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseHistoryRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseHistoryRequest.java
@@ -1,0 +1,27 @@
+package com.ogjg.daitgym.journal.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ExerciseHistoryRequest {
+
+    private Long exerciseListId;
+    private int setNum;
+    private int weight;
+    private int repetitionCount;
+
+    /**
+     * 운동목록을 처음 생성할 때
+     * 생성되는 default 운동기록들을
+     * 어떤 운동목록에 생성되는 운동기록인지 넣어주기 위해 사용
+     */
+    public ExerciseHistoryRequest putExerciseListId(Long exerciseListId) {
+        this.exerciseListId = exerciseListId;
+        return this;
+    }
+
+}

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseListRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseListRequest.java
@@ -1,0 +1,21 @@
+package com.ogjg.daitgym.journal.dto.request;
+
+import com.ogjg.daitgym.domain.journal.TimeTemplate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ExerciseListRequest {
+
+    private Long exerciseJournalId;
+    private String exerciseName;
+    private int exerciseNum;
+    private TimeTemplate restTime;
+    List<ExerciseHistoryRequest> exerciseSets = new ArrayList<>();
+}

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/JournalRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/JournalRequest.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.journal.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class JournalRequest {
+
+    private LocalDate journalDate;
+    private List<ExerciseListRequest> exercises = new ArrayList<>();
+
+}

--- a/src/main/java/com/ogjg/daitgym/journal/exception/NotFoundExercise.java
+++ b/src/main/java/com/ogjg/daitgym/journal/exception/NotFoundExercise.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.journal.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundExercise extends CustomException {
+    public NotFoundExercise() {
+        super(ErrorCode.NOT_FOUND_EXERCISE);
+    }
+
+    public NotFoundExercise(String message) {
+        super(ErrorCode.NOT_FOUND_EXERCISE, message);
+    }
+
+    public NotFoundExercise(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_EXERCISE, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/journal/exception/NotFoundExerciseList.java
+++ b/src/main/java/com/ogjg/daitgym/journal/exception/NotFoundExerciseList.java
@@ -1,0 +1,21 @@
+package com.ogjg.daitgym.journal.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundExerciseList extends CustomException {
+
+    public NotFoundExerciseList() {
+        super(ErrorCode.NOT_FOUND_EXERCISE_LIST);
+    }
+
+    public NotFoundExerciseList(String message) {
+        super(ErrorCode.NOT_FOUND_EXERCISE_LIST, message);
+    }
+
+    public NotFoundExerciseList(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_EXERCISE_LIST, errorData);
+    }
+
+}

--- a/src/main/java/com/ogjg/daitgym/journal/exception/NotFoundJournal.java
+++ b/src/main/java/com/ogjg/daitgym/journal/exception/NotFoundJournal.java
@@ -1,0 +1,20 @@
+package com.ogjg.daitgym.journal.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundJournal extends CustomException {
+
+    public NotFoundJournal() {
+        super(ErrorCode.NOT_FOUND_JOURNAL);
+    }
+
+    public NotFoundJournal(String message) {
+        super(ErrorCode.NOT_FOUND_JOURNAL, message);
+    }
+
+    public NotFoundJournal(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_JOURNAL, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/journal/exception/UserNotAuthorizedForJournal.java
+++ b/src/main/java/com/ogjg/daitgym/journal/exception/UserNotAuthorizedForJournal.java
@@ -1,0 +1,20 @@
+package com.ogjg.daitgym.journal.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class UserNotAuthorizedForJournal extends CustomException {
+
+    public UserNotAuthorizedForJournal() {
+        super(ErrorCode.USER_NOT_AUTHORIZED_JOURNAL);
+    }
+
+    public UserNotAuthorizedForJournal(String message) {
+        super(ErrorCode.USER_NOT_AUTHORIZED_JOURNAL, message);
+    }
+
+    public UserNotAuthorizedForJournal(ErrorData errorData) {
+        super(ErrorCode.USER_NOT_AUTHORIZED_JOURNAL, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/journal/repository/exercise/ExerciseRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/exercise/ExerciseRepository.java
@@ -1,0 +1,10 @@
+package com.ogjg.daitgym.journal.repository.exercise;
+
+import com.ogjg.daitgym.domain.Exercise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+    Optional<Exercise> findByName(String name);
+}

--- a/src/main/java/com/ogjg/daitgym/journal/repository/exercisehistory/ExerciseHistoryRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/exercisehistory/ExerciseHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.ogjg.daitgym.journal.repository.exercisehistory;
+
+import com.ogjg.daitgym.domain.journal.ExerciseHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExerciseHistoryRepository extends JpaRepository<ExerciseHistory, Long>, ExerciseHistoryRepositoryCustom {
+}

--- a/src/main/java/com/ogjg/daitgym/journal/repository/exerciselist/ExerciseListRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/exerciselist/ExerciseListRepository.java
@@ -1,0 +1,7 @@
+package com.ogjg.daitgym.journal.repository.exerciselist;
+
+import com.ogjg.daitgym.domain.journal.ExerciseList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExerciseListRepository extends JpaRepository<ExerciseList, Long> {
+}

--- a/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
@@ -1,0 +1,9 @@
+package com.ogjg.daitgym.journal.repository.journal;
+
+import com.ogjg.daitgym.domain.journal.ExerciseJournal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExerciseJournalRepository extends JpaRepository<ExerciseJournal, Long>, ExerciseJournalRepositoryCustom {
+
+
+}

--- a/src/main/java/com/ogjg/daitgym/journal/service/ExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/journal/service/ExerciseJournalService.java
@@ -1,0 +1,136 @@
+package com.ogjg.daitgym.journal.service;
+
+import com.ogjg.daitgym.domain.Exercise;
+import com.ogjg.daitgym.domain.User;
+import com.ogjg.daitgym.domain.journal.ExerciseHistory;
+import com.ogjg.daitgym.domain.journal.ExerciseJournal;
+import com.ogjg.daitgym.domain.journal.ExerciseList;
+import com.ogjg.daitgym.journal.dto.request.ExerciseHistoryRequest;
+import com.ogjg.daitgym.journal.dto.request.ExerciseListRequest;
+import com.ogjg.daitgym.journal.exception.NotFoundExercise;
+import com.ogjg.daitgym.journal.exception.NotFoundExerciseList;
+import com.ogjg.daitgym.journal.exception.NotFoundJournal;
+import com.ogjg.daitgym.journal.exception.UserNotAuthorizedForJournal;
+import com.ogjg.daitgym.journal.repository.exercise.ExerciseRepository;
+import com.ogjg.daitgym.journal.repository.exercisehistory.ExerciseHistoryRepository;
+import com.ogjg.daitgym.journal.repository.exerciselist.ExerciseListRepository;
+import com.ogjg.daitgym.journal.repository.journal.ExerciseJournalRepository;
+import com.ogjg.daitgym.user.exception.NotFoundUser;
+import com.ogjg.daitgym.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExerciseJournalService {
+
+    private final ExerciseJournalRepository exerciseJournalRepository;
+    private final ExerciseListRepository exerciseListRepository;
+    private final ExerciseHistoryRepository exerciseHistoryRepository;
+    private final ExerciseRepository exerciseRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 빈 운동일지 생성하기
+     */
+    @Transactional
+    public void createJournal(String email, LocalDate journalDate) {
+        User user = userRepository.findById(email).orElseThrow(NotFoundUser::new);
+
+        exerciseJournalRepository.save(
+                ExerciseJournal.createJournal(user, journalDate)
+        );
+    }
+
+    /**
+     * 운동일지에 운동 추가하기
+     */
+    @Transactional
+    public void createExerciseList(
+            String email,
+            ExerciseListRequest exerciseListRequest
+    ) {
+
+        ExerciseJournal userJournal = isAuthorizedForJournal(email, exerciseListRequest.getExerciseJournalId());
+        Exercise userExercise = findExercise(exerciseListRequest.getExerciseName());
+
+        ExerciseList exerciseList = exerciseListRepository.save(
+                ExerciseList.createExercise(
+                        userJournal,
+                        userExercise,
+                        exerciseListRequest
+                )
+        );
+
+        List<ExerciseHistoryRequest> defaultExerciseHistory =
+                exerciseListRequest.getExerciseSets()
+                        .stream()
+                        .map(exerciseHistoryRequest -> exerciseHistoryRequest.putExerciseListId(exerciseList.getId()))
+                        .toList();
+
+        defaultExerciseHistory.forEach(
+                exerciseHistoryRequest -> createExerciseHistory(email, exerciseHistoryRequest)
+        );
+    }
+
+    /**
+     * 운동목록에 운동 기록 생성하기
+     */
+    @Transactional
+    public void createExerciseHistory(String email, ExerciseHistoryRequest exerciseHistoryRequest) {
+
+        ExerciseList exerciseList = findExerciseList(exerciseHistoryRequest.getExerciseListId());
+        isAuthorizedForJournal(email, exerciseList.getExerciseJournal().getId());
+
+        exerciseHistoryRepository.save(
+                ExerciseHistory.createExerciseHistory(exerciseList, exerciseHistoryRequest)
+        );
+    }
+
+    /**
+     * 일지 작성자인지 확인
+     */
+    private ExerciseJournal isAuthorizedForJournal(String email, Long JournalId) {
+        ExerciseJournal exerciseJournal = findExerciseJournal(JournalId);
+
+        if (!email.equals(exerciseJournal.getUser().getEmail())) {
+            throw new UserNotAuthorizedForJournal();
+        }
+
+        return exerciseJournal;
+    }
+
+    /**
+     * 일지 검색
+     * 일지 Id로 일지 존재하는지 확인하기
+     */
+    private ExerciseJournal findExerciseJournal(Long journalId) {
+        return exerciseJournalRepository.findById(journalId)
+                .orElseThrow(NotFoundJournal::new);
+    }
+
+    /**
+     * 운동검색
+     * 운동이름으로 운동 존재하는지 확인하기
+     */
+    private Exercise findExercise(String exerciseName) {
+        return exerciseRepository.findByName(exerciseName)
+                .orElseThrow(NotFoundExercise::new);
+    }
+
+    /**
+     * 일지 목록 검색
+     * 일지 목록 ID로 일지목록 검색
+     */
+    private ExerciseList findExerciseList(Long exerciseListId) {
+        return exerciseListRepository.findById(exerciseListId)
+                .orElseThrow(NotFoundExerciseList::new);
+    }
+
+}


### PR DESCRIPTION
### 빈 운동일지 생성 구현

### 운동일지에 운동목록을 생성 구현
- 운동목록을 추가하는 사람이 작성자인지 확인 후 운동목록 추가
- 운동목록을 생성시 default 운동기록목록 같이 생성
- 가독성을 위해 정적팩터리 메서드 패턴을 통해 Request 객체 생성

### 운동목록에 운동기록 추가 구현
- 운동목록에 운동기록을 추가하는 사람이 작성자인지 확인 후 운동기록 추가

### CustomException
- log.error를 사용하지 않아 에러메시지가 프론트응답으로만 날아가는 버그를 수정

### BaseEntity
- BaseEntity의 createdAt과 modifiedAt이 적용되지않아 Applciation파일에 @EnableJpaAuditing annotation 추가