### PR TITLE
Feat : DIG-65 OAuth2 카카오 소셜로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ gradle-app.setting
 application-local.yml
 application-dev.yml
 application-prod.yml
+application-oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
 	//Querydsl 추가
@@ -42,8 +43,10 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // oauth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	// jjwt
+    // jjwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/ogjg/daitgym/config/security/HandlerConfig.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/HandlerConfig.java
@@ -1,0 +1,28 @@
+package com.ogjg.daitgym.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ogjg.daitgym.config.security.oauth.handler.Oauth2AuthenticationSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.RequestCache;
+
+@Configuration
+@RequiredArgsConstructor
+public class HandlerConfig {
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler() {
+        return new Oauth2AuthenticationSuccessHandler(httpSessionRequestCache(), objectMapper);
+    }
+
+    @Bean
+    public RequestCache httpSessionRequestCache() {
+        return new HttpSessionRequestCache();
+    }
+}
+
+

--- a/src/main/java/com/ogjg/daitgym/config/security/OAuth2JwtUserDetails.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/OAuth2JwtUserDetails.java
@@ -1,0 +1,81 @@
+package com.ogjg.daitgym.config.security;
+
+import com.ogjg.daitgym.config.security.oauth.dto.OAuthAttributes;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class OAuth2JwtUserDetails extends DefaultOAuth2User implements UserDetails {
+
+    private final OAuthAttributes oAuthAttributes;
+
+    public OAuth2JwtUserDetails(
+            Collection<? extends GrantedAuthority> authorities,
+            OAuthAttributes oAuthAttributes,
+            boolean alreadyJoined
+    ) {
+        super(authorities, oAuthAttributes.getAttributes(), oAuthAttributes.getNameAttributeKey());
+        this.oAuthAttributes = oAuthAttributes;
+        this.oAuthAttributes.setAlreadyJoined(alreadyJoined);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return super.getAttributes();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return super.getAuthorities();
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return getName();
+    }
+
+    public String getNickname() {
+        return "";
+    }
+
+    public String getEmail() {
+        return oAuthAttributes.getEmail();
+    }
+
+    public boolean isAlreadyJoined() {
+        return oAuthAttributes.isAlreadyJoined();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return super.getName();
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.ogjg.daitgym.config.security;
+
+import com.ogjg.daitgym.config.security.oauth.CustomOAuth2UserService;
+import com.ogjg.daitgym.domain.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsUtils;
+
+@Configuration
+@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(CsrfConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .headers((headers ->
+                                headers
+                                        .frameOptions(Customizer.withDefaults())
+                                        .frameOptions((frameOptionsConfig) -> frameOptionsConfig.sameOrigin())
+                        )
+                )
+                .authorizeHttpRequests(
+                        authorize -> authorize
+                                .requestMatchers(CorsUtils::isPreFlightRequest)
+                                .permitAll()
+                                .requestMatchers("/api/admins/**").hasRole(Role.ADMIN.name())
+                                .requestMatchers("/api/trainers/**").hasRole(Role.TRAINER.name())
+                                .requestMatchers("/api/profiles/**").hasRole(Role.USER.name())
+                                .requestMatchers("/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .logout(
+                        (logout) -> logout.logoutSuccessUrl("/")
+                )
+                .oauth2Login(
+                        (oauth2) -> oauth2
+                                .userInfoEndpoint((endPoint) -> endPoint
+                                        .userService(customOAuth2UserService)
+                                )
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.web.cors.CorsUtils;
 
 @Configuration
@@ -18,6 +19,8 @@ import org.springframework.web.cors.CorsUtils;
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
+
+    private final AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -45,6 +48,7 @@ public class SecurityConfig {
                 )
                 .oauth2Login(
                         (oauth2) -> oauth2
+                                .successHandler(oauth2AuthenticationSuccessHandler)
                                 .userInfoEndpoint((endPoint) -> endPoint
                                         .userService(customOAuth2UserService)
                                 )

--- a/src/main/java/com/ogjg/daitgym/config/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/oauth/CustomOAuth2UserService.java
@@ -37,7 +37,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         );
     }
 
-    private static OAuthAttributes getOAuthAttributes(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+    private OAuthAttributes getOAuthAttributes(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint()
                 .getUserNameAttributeName();

--- a/src/main/java/com/ogjg/daitgym/config/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,61 @@
+package com.ogjg.daitgym.config.security.oauth;
+
+import com.ogjg.daitgym.config.security.OAuth2JwtUserDetails;
+import com.ogjg.daitgym.config.security.oauth.dto.OAuthAttributes;
+import com.ogjg.daitgym.domain.User;
+import com.ogjg.daitgym.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        OAuthAttributes attributes = getOAuthAttributes(userRequest, oAuth2User);
+
+        User user = saveOrUpdate(attributes);
+
+        return new OAuth2JwtUserDetails(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey())),
+                attributes,
+                isAlreadyJoinedUser(attributes.getEmail())
+        );
+    }
+
+    private static OAuthAttributes getOAuthAttributes(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        return OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+    }
+
+    private boolean isAlreadyJoinedUser(String email) {
+        return userRepository.findByEmail(email)
+                .isPresent();
+    }
+
+    // todo : 다른 소셜로그인이 추가된다 가장하면 registrationId를 사용해야한다.
+    // todo : 싱크 관련 요구사항 종합 필요
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .orElse(attributes.toEntity());
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/config/security/oauth/dto/LoginResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/oauth/dto/LoginResponseDto.java
@@ -1,0 +1,40 @@
+package com.ogjg.daitgym.config.security.oauth.dto;
+
+import com.ogjg.daitgym.config.security.OAuth2JwtUserDetails;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class LoginResponseDto {
+    private String email;
+
+    private String nickname;
+
+    private String userImg;
+
+    private String initialRequestUrl;
+
+    private boolean isAlreadyJoined;
+
+    public LoginResponseDto(String email, String nickname, String userImg, String initialRequestUrl, boolean isAlreadyJoined) {
+        this.email = email;
+        this.nickname = nickname;
+        this.userImg = userImg;
+        this.initialRequestUrl = initialRequestUrl;
+        this.isAlreadyJoined = isAlreadyJoined;
+    }
+
+    public static LoginResponseDto of(OAuth2JwtUserDetails oAuth2UserDetails, String initialRequestUrl) {
+        return LoginResponseDto.builder()
+                .nickname(oAuth2UserDetails.getNickname())
+                .email(oAuth2UserDetails.getEmail())
+                .userImg("default")
+                .initialRequestUrl(initialRequestUrl)
+                .isAlreadyJoined(oAuth2UserDetails.isAlreadyJoined())
+                .build();
+    }
+}
+

--- a/src/main/java/com/ogjg/daitgym/config/security/oauth/dto/OAuthAttributes.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/oauth/dto/OAuthAttributes.java
@@ -1,0 +1,66 @@
+package com.ogjg.daitgym.config.security.oauth.dto;
+
+import com.ogjg.daitgym.domain.Role;
+import com.ogjg.daitgym.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes implements Serializable {
+    private Map<String, Object> attributes;
+
+    private String nameAttributeKey;
+
+    private String name;
+
+    private String nickname;
+
+    private String email;
+
+    private String picture;
+
+    private boolean isAlreadyJoined;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String nickname, String name, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.nickname = nickname;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String,Object> attributes) {
+        return ofKakao("id", attributes);
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String,Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        return OAuthAttributes.builder()
+                .name((String) profile.get("nickname")) // 이름은 동의없이 못받는다.
+                .nickname((String) profile.get("nickname"))
+                .email((String) kakaoAccount.get("email"))
+                .picture((String) profile.get("profile_image_url"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .nickname(nickname)
+                .email(email)
+                .role(Role.USER)
+                .build();
+    }
+
+    public void setAlreadyJoined(boolean isAlreadyJoined) {
+        this.isAlreadyJoined = isAlreadyJoined;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/config/security/oauth/handler/Oauth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/oauth/handler/Oauth2AuthenticationSuccessHandler.java
@@ -1,0 +1,52 @@
+package com.ogjg.daitgym.config.security.oauth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.config.security.OAuth2JwtUserDetails;
+import com.ogjg.daitgym.config.security.oauth.dto.LoginResponseDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class Oauth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private static final String HOME_URL = "/";
+
+    private final RequestCache requestCache;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2JwtUserDetails OAuth2UserDetails = (OAuth2JwtUserDetails) authentication.getPrincipal();
+        String cachedUrl = getCachedUrlOrDefault(request, response);
+
+        objectMapper.writeValue(
+                response.getWriter(),
+                new ApiResponse<>(
+                        ErrorCode.SUCCESS,
+                        LoginResponseDto.of(OAuth2UserDetails, cachedUrl)
+                )
+        );
+    }
+
+    private String getCachedUrlOrDefault(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        SavedRequest savedRequest = requestCache.getRequest(request, response);
+        if (savedRequest != null) {
+            return savedRequest.getRedirectUrl();
+        } else {
+            // 세션 만료 대비
+            return HOME_URL;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   profiles:
-    include: dev
+    include:
+      - dev
+      - oauth


### PR DESCRIPTION
### Feat : DIG-65 oauth2, security 관련 의존성 추가
- [x] oauth2-client : oauth2 및 secuirty 의존성 추가
- [x] security-test 의존성 추가

### Feat : DIG-65 oauth2 설정 추가를 위해 yml 수정
- [x] nclude 항목에 oauth 추가
- [x] gitignore에 application-oauth.yml 추가

### Feat : OAuth2 카카오 소셜 로그인 기능 구현
- [x] SecurityConfig 추가
  - oauthLogin() 사용
  - userService를 커스텀해서 사용
- [x] CustomOAuth2UserService
  - 커스텀한 UserService
  - loadUser에서 provider의 토큰 정보와 가입 여부를 확인해서 반환
- [x] OAuthAttributes
  - OAuth2에서 받아온 정보를 바인딩하고 전달하는 객체
  - 다른 소셜로그인 확장을 고려해 kakao 전용 생성메서드 구현
  - OAuth2JwtUserDetails에 컴포지션하기 위해 Serializable 구현
- [x] OAuth2JwtUserDetails
  - OAuth2 로그인 후, Jwt 인증 후 같이 사용학 위한 UserDetails 구현체
  - OAuth2 인증 로직에서 사용하기 위해 DefaultOAuth2User 상속

###  Feat : DIF-65 OAuth2 인증 성공 후 동작하는 Handler 추가
- [x] HandlerConfig 추가
- [x] SecurityConfig에 핸들러 주입
- [x] Oauth2AuthenticationSuccessHandler 추가
  - OAuth2 인증 성공 시 동작하는 핸들러
  - 로그인 정보를 응답으로 보내준다.
- [x] LoginResponseDto 추가
  - 핸들러에서 응답으로 내려주는 dto
  - 회원 정보, 캐시된 url, 가입자인지 여부 포함