### PR TITLE
Feat : DIG-85 피드 운동일지 추가, 삭제 구현

### DIFF
--- a/src/main/java/com/ogjg/daitgym/comment/feedExerciseJournal/repository/FeedExerciseJournalCommentRepository.java
+++ b/src/main/java/com/ogjg/daitgym/comment/feedExerciseJournal/repository/FeedExerciseJournalCommentRepository.java
@@ -1,5 +1,6 @@
 package com.ogjg.daitgym.comment.feedExerciseJournal.repository;
 
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournalComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,4 +21,6 @@ public interface FeedExerciseJournalCommentRepository extends JpaRepository<Feed
     int countByFeedExerciseJournalIdAndParentIdIsNull(Long feedJournalId);
 
     int countByFeedExerciseJournalIdAndParentIdIsNotNull(Long feedJournalId);
+
+    void deleteAllByFeedExerciseJournal(FeedExerciseJournal feedExerciseJournal);
 }

--- a/src/main/java/com/ogjg/daitgym/domain/TimeTemplate.java
+++ b/src/main/java/com/ogjg/daitgym/domain/TimeTemplate.java
@@ -1,4 +1,4 @@
-package com.ogjg.daitgym.domain.journal;
+package com.ogjg.daitgym.domain;
 
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.Max;

--- a/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournal.java
+++ b/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournal.java
@@ -6,6 +6,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -24,4 +27,10 @@ public class FeedExerciseJournal extends BaseEntity {
     @JoinColumn(name = "journal_id")
     private ExerciseJournal exerciseJournal;
 
+    @OneToMany(mappedBy = "feedExerciseJournal")
+    private List<FeedExerciseJournalImage> feedExerciseJournalImage = new ArrayList<>();
+
+    public FeedExerciseJournal(ExerciseJournal exerciseJournal) {
+        this.exerciseJournal = exerciseJournal;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournal.java
+++ b/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournal.java
@@ -28,7 +28,7 @@ public class FeedExerciseJournal extends BaseEntity {
     private ExerciseJournal exerciseJournal;
 
     @OneToMany(mappedBy = "feedExerciseJournal")
-    private List<FeedExerciseJournalImage> feedExerciseJournalImage = new ArrayList<>();
+    private List<FeedExerciseJournalImage> feedExerciseJournalImages = new ArrayList<>();
 
     public FeedExerciseJournal(ExerciseJournal exerciseJournal) {
         this.exerciseJournal = exerciseJournal;

--- a/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournalCollection.java
+++ b/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournalCollection.java
@@ -2,7 +2,6 @@ package com.ogjg.daitgym.domain.feed;
 
 import com.ogjg.daitgym.domain.BaseEntity;
 import com.ogjg.daitgym.domain.User;
-import com.ogjg.daitgym.domain.journal.ExerciseJournal;
 import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -30,6 +29,14 @@ public class FeedExerciseJournalCollection extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "feed_exercise_journal_id")
     private FeedExerciseJournal feedExerciseJournal;
+
+    public FeedExerciseJournalCollection(
+            User user, FeedExerciseJournal feedExerciseJournal
+    ) {
+        this.pk = new PK(user.getEmail(), feedExerciseJournal.getId());
+        this.user = user;
+        this.feedExerciseJournal = feedExerciseJournal;
+    }
 
     @Getter
     @Embeddable

--- a/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournalImage.java
+++ b/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournalImage.java
@@ -24,4 +24,8 @@ public class FeedExerciseJournalImage {
 
     private String imageUrl;
 
+    public FeedExerciseJournalImage(FeedExerciseJournal feedExerciseJournal, String imageUrl) {
+        this.feedExerciseJournal = feedExerciseJournal;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
@@ -1,6 +1,7 @@
 package com.ogjg.daitgym.domain.journal;
 
 import com.ogjg.daitgym.domain.BaseEntity;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import com.ogjg.daitgym.domain.User;
 import com.ogjg.daitgym.journal.dto.request.ExerciseJournalCompleteRequest;
 import com.ogjg.daitgym.journal.dto.request.ExerciseJournalShareRequest;

--- a/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
@@ -70,7 +70,7 @@ public class ExerciseJournal extends BaseEntity {
         this.split = exerciseJournalShareRequest.getSplit();
     }
 
-    public void feedJournalDelete() {
+    public void privateVisible() {
         this.isVisible = false;
     }
 

--- a/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseList.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseList.java
@@ -1,6 +1,7 @@
 package com.ogjg.daitgym.domain.journal;
 
 import com.ogjg.daitgym.domain.BaseEntity;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import com.ogjg.daitgym.domain.exercise.Exercise;
 import com.ogjg.daitgym.journal.dto.request.ExerciseListRequest;
 import com.ogjg.daitgym.journal.dto.request.UpdateRestTimeRequest;

--- a/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
@@ -1,0 +1,35 @@
+package com.ogjg.daitgym.feed.controller;
+
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.feed.service.FeedExerciseJournalService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feeds/journal")
+public class FeedExerciseJournalController {
+
+    private final FeedExerciseJournalService feedExerciseJournalService;
+
+    /**
+     * 운동일지 피드 삭제
+     */
+    @DeleteMapping("{feedJournalId}")
+    public ApiResponse<Void> deleteFeedJournal(
+            @PathVariable("feedJournalId") Long feedJournalId,
+//            todo Token User
+            String email
+    ) {
+        String email1 = "dlehdwls21@naver.com";
+        feedExerciseJournalService.deleteFeedJournal(email1, feedJournalId);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+}

--- a/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
@@ -2,13 +2,11 @@ package com.ogjg.daitgym.feed.controller;
 
 import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalCountResponse;
 import com.ogjg.daitgym.feed.service.FeedExerciseJournalService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -30,6 +28,18 @@ public class FeedExerciseJournalController {
         String email1 = "dlehdwls21@naver.com";
         feedExerciseJournalService.deleteFeedJournal(email1, feedJournalId);
         return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 운동일지 수 가져오기
+     */
+    @GetMapping("/count/{nickname}")
+    public ApiResponse<FeedExerciseJournalCountResponse> countExerciseJournal(
+            @PathVariable("nickname") String nickname
+    ) {
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                feedExerciseJournalService.countExerciseJournal(nickname));
     }
 
 }

--- a/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
@@ -42,4 +42,17 @@ public class FeedExerciseJournalController {
                 feedExerciseJournalService.countExerciseJournal(nickname));
     }
 
+    /**
+     * 피드 운동일지 스크랩하기
+     */
+    @PostMapping("/{feedJournalId}/scrap")
+    public ApiResponse<Void> feedExerciseJournalScrap(
+            @PathVariable("feedJournalId") Long feedJournalId,
+            //todo token 추출
+            String email
+    ) {
+        String email1 = "dlehdwls21@naver.com";
+        feedExerciseJournalService.feedExerciseJournalScrap(email1, feedJournalId);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedExerciseJournalCountResponse.java
+++ b/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedExerciseJournalCountResponse.java
@@ -1,0 +1,17 @@
+package com.ogjg.daitgym.feed.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FeedExerciseJournalCountResponse {
+
+    private int count;
+
+    public FeedExerciseJournalCountResponse(int count) {
+        this.count = count;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalCollectionRepository.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalCollectionRepository.java
@@ -1,0 +1,9 @@
+package com.ogjg.daitgym.feed.repository;
+
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournalCollection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedExerciseJournalCollectionRepository extends JpaRepository<FeedExerciseJournalCollection, Long> {
+
+
+}

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalImageRepository.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalImageRepository.java
@@ -1,0 +1,11 @@
+package com.ogjg.daitgym.feed.repository;
+
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournalImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedExerciseJournalImageRepository extends JpaRepository<FeedExerciseJournalImage, Long> {
+
+    void deleteAllByFeedExerciseJournal(FeedExerciseJournal feedExerciseJournal);
+
+}

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepository.java
@@ -1,7 +1,13 @@
 package com.ogjg.daitgym.feed.repository;
 
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.domain.journal.ExerciseJournal;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeedExerciseJournalRepository extends JpaRepository<FeedExerciseJournal, Long> {
+
+    Optional<FeedExerciseJournal> findByExerciseJournal(ExerciseJournal exerciseJournal);
+
 }

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
@@ -2,14 +2,18 @@ package com.ogjg.daitgym.feed.service;
 
 import com.ogjg.daitgym.comment.feedExerciseJournal.exception.NotFoundFeedJournal;
 import com.ogjg.daitgym.comment.feedExerciseJournal.repository.FeedExerciseJournalCommentRepository;
+import com.ogjg.daitgym.domain.User;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournalImage;
 import com.ogjg.daitgym.domain.journal.ExerciseJournal;
+import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalCountResponse;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalImageRepository;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalRepository;
 import com.ogjg.daitgym.journal.exception.UserNotAuthorizedForJournal;
 import com.ogjg.daitgym.journal.repository.journal.ExerciseJournalRepository;
 import com.ogjg.daitgym.like.feedExerciseJournal.repository.FeedExerciseJournalLikeRepository;
+import com.ogjg.daitgym.user.exception.NotFoundUser;
+import com.ogjg.daitgym.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +32,7 @@ public class FeedExerciseJournalService {
     private final ExerciseJournalRepository exerciseJournalRepository;
     private final FeedExerciseJournalCommentRepository feedExerciseJournalCommentRepository;
     private final FeedExerciseJournalLikeRepository feedExerciseJournalLikeRepository;
+    private final UserRepository userRepository;
 
     /*
      * todo 이미지 넘어올시 이미지 저장 추가
@@ -87,8 +92,16 @@ public class FeedExerciseJournalService {
     }
 
     /**
-     * 피드 운동일지 수
+     * 운동일지 수 조회
      */
+    @Transactional(readOnly = true)
+    public FeedExerciseJournalCountResponse countExerciseJournal(String nickname) {
+        User user = findUserByNickname(nickname);
+
+        return new FeedExerciseJournalCountResponse(
+                exerciseJournalRepository.countByUserAndCompleted(user, true)
+        );
+    }
 
     /**
      * 피드 운동일지 보관함 조회 목록보기
@@ -105,6 +118,11 @@ public class FeedExerciseJournalService {
     private FeedExerciseJournal findFeedJournalById(Long feedJournalId) {
         return feedExerciseJournalRepository.findById(feedJournalId)
                 .orElseThrow(NotFoundFeedJournal::new);
+    }
+
+    private User findUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
+                .orElseThrow(NotFoundUser::new);
     }
 
     /**

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
@@ -4,9 +4,11 @@ import com.ogjg.daitgym.comment.feedExerciseJournal.exception.NotFoundFeedJourna
 import com.ogjg.daitgym.comment.feedExerciseJournal.repository.FeedExerciseJournalCommentRepository;
 import com.ogjg.daitgym.domain.User;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournalCollection;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournalImage;
 import com.ogjg.daitgym.domain.journal.ExerciseJournal;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalCountResponse;
+import com.ogjg.daitgym.feed.repository.FeedExerciseJournalCollectionRepository;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalImageRepository;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalRepository;
 import com.ogjg.daitgym.journal.exception.UserNotAuthorizedForJournal;
@@ -32,10 +34,12 @@ public class FeedExerciseJournalService {
     private final ExerciseJournalRepository exerciseJournalRepository;
     private final FeedExerciseJournalCommentRepository feedExerciseJournalCommentRepository;
     private final FeedExerciseJournalLikeRepository feedExerciseJournalLikeRepository;
+    private final FeedExerciseJournalCollectionRepository feedExerciseJournalCollectionRepository;
     private final UserRepository userRepository;
 
     /*
      * todo 이미지 넘어올시 이미지 저장 추가
+     * todo 이미지 null 이면 기본 이미지 저장
      * 운동일지 공유시 피드에 생성
      * 이미지가 넘어오면 저장
      * */
@@ -68,6 +72,29 @@ public class FeedExerciseJournalService {
      */
 
     /**
+     * 피드 운동일지 보관함 조회 목록보기
+     */
+
+    /**
+     * 내 피드 운동일지 조회
+     */
+
+
+    /**
+     * 피드 운동일지 스크랩
+     */
+    public void feedExerciseJournalScrap(
+            String email, Long feedExerciseJournalId
+    ) {
+        feedExerciseJournalCollectionRepository.save(
+                new FeedExerciseJournalCollection(
+                        findUserByEmail(email),
+                        findFeedJournalById(feedExerciseJournalId)
+                )
+        );
+    }
+
+    /**
      * 피드 운동일지 삭제하기
      * 피드 좋아요 삭제
      * 피드 댓글 삭제
@@ -88,7 +115,7 @@ public class FeedExerciseJournalService {
 
         feedExerciseJournalRepository.delete(feedJournal);
 
-        feedJournal.getExerciseJournal().feedJournalDelete();
+        feedJournal.getExerciseJournal().privateVisible();
     }
 
     /**
@@ -99,18 +126,9 @@ public class FeedExerciseJournalService {
         User user = findUserByNickname(nickname);
 
         return new FeedExerciseJournalCountResponse(
-                exerciseJournalRepository.countByUserAndCompleted(user, true)
+                exerciseJournalRepository.countByUserAndIsCompleted(user, true)
         );
     }
-
-    /**
-     * 피드 운동일지 보관함 조회 목록보기
-     */
-
-    /**
-     * 내피드 운동일지 조회
-     */
-
 
     /**
      * Id로 feedJournal 검색
@@ -122,6 +140,11 @@ public class FeedExerciseJournalService {
 
     private User findUserByNickname(String nickname) {
         return userRepository.findByNickname(nickname)
+                .orElseThrow(NotFoundUser::new);
+    }
+
+    private User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
                 .orElseThrow(NotFoundUser::new);
     }
 

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
@@ -1,0 +1,119 @@
+package com.ogjg.daitgym.feed.service;
+
+import com.ogjg.daitgym.comment.feedExerciseJournal.exception.NotFoundFeedJournal;
+import com.ogjg.daitgym.comment.feedExerciseJournal.repository.FeedExerciseJournalCommentRepository;
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournalImage;
+import com.ogjg.daitgym.domain.journal.ExerciseJournal;
+import com.ogjg.daitgym.feed.repository.FeedExerciseJournalImageRepository;
+import com.ogjg.daitgym.feed.repository.FeedExerciseJournalRepository;
+import com.ogjg.daitgym.journal.exception.UserNotAuthorizedForJournal;
+import com.ogjg.daitgym.journal.repository.journal.ExerciseJournalRepository;
+import com.ogjg.daitgym.like.feedExerciseJournal.repository.FeedExerciseJournalLikeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedExerciseJournalService {
+
+    private final FeedExerciseJournalRepository feedExerciseJournalRepository;
+    private final FeedExerciseJournalImageRepository feedExerciseJournalImageRepository;
+    private final ExerciseJournalRepository exerciseJournalRepository;
+    private final FeedExerciseJournalCommentRepository feedExerciseJournalCommentRepository;
+    private final FeedExerciseJournalLikeRepository feedExerciseJournalLikeRepository;
+
+    /*
+     * todo 이미지 넘어올시 이미지 저장 추가
+     * 운동일지 공유시 피드에 생성
+     * 이미지가 넘어오면 저장
+     * */
+    @Transactional
+    public void shareJournalFeed(
+            ExerciseJournal exerciseJournal, List<MultipartFile> imgFiles
+    ) {
+        FeedExerciseJournal feedExercise = feedExerciseJournalRepository.save(new FeedExerciseJournal(exerciseJournal));
+
+        if (!imgFiles.isEmpty()) {
+            imgFiles.forEach(
+                    multipartFile -> feedExerciseJournalImageRepository.save(
+                            //todo s3에 저장 후 이미지경로 입력하기
+                            new FeedExerciseJournalImage(feedExercise, "s3 이미지 파일 경로")
+                    )
+            );
+        }
+    }
+
+    /**
+     * 피드 운동일지 가져오기 목록보기 무한 스크롤
+     * 분할 및 부위 분할 및 부위로 검색가능
+     * 팔로우 => ?
+     * 전체 => ?
+     * 추천 => ?
+     */
+
+    /**
+     * 피드 운동일지 상세정보 가져오기
+     */
+
+    /**
+     * 피드 운동일지 삭제하기
+     * 피드 좋아요 삭제
+     * 피드 댓글 삭제
+     * 피드 이미지 삭제
+     * 운동일지 공개여부 false로 변경
+     */
+    @Transactional
+    public void deleteFeedJournal(
+            String email, Long feedJournalId
+    ) {
+        FeedExerciseJournal feedJournal = findFeedJournalById(feedJournalId);
+        feedExerciseJournalCommentRepository.deleteAllByFeedExerciseJournal(feedJournal);
+        feedExerciseJournalLikeRepository.deleteAllByFeedExerciseJournal(feedJournal);
+        feedExerciseJournalImageRepository.deleteAllByFeedExerciseJournal(feedJournal);
+
+        if (!feedJournal.getExerciseJournal().getUser().getEmail().equals(email))
+            throw new UserNotAuthorizedForJournal();
+
+        feedExerciseJournalRepository.delete(feedJournal);
+
+        feedJournal.getExerciseJournal().feedJournalDelete();
+    }
+
+    /**
+     * 피드 운동일지 수
+     */
+
+    /**
+     * 피드 운동일지 보관함 조회 목록보기
+     */
+
+    /**
+     * 내피드 운동일지 조회
+     */
+
+
+    /**
+     * Id로 feedJournal 검색
+     */
+    private FeedExerciseJournal findFeedJournalById(Long feedJournalId) {
+        return feedExerciseJournalRepository.findById(feedJournalId)
+                .orElseThrow(NotFoundFeedJournal::new);
+    }
+
+    /**
+     * 운동일지로 피드 운동일지 찾기
+     */
+    public FeedExerciseJournal findFeedJournalByJournal(ExerciseJournal exerciseJournal) {
+        return feedExerciseJournalRepository.findByExerciseJournal(exerciseJournal)
+                .orElseThrow(NotFoundFeedJournal::new);
+    }
+
+
+}

--- a/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
@@ -9,8 +9,10 @@ import com.ogjg.daitgym.journal.service.ExerciseJournalService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -187,10 +189,11 @@ public class ExerciseJournalController {
 //            todo email가져오기
             String email,
             @PathVariable("journalId") Long journalId,
-            @RequestBody ExerciseJournalShareRequest exerciseJournalShareRequest
+            @RequestPart("share") ExerciseJournalShareRequest exerciseJournalShareRequest,
+            @RequestPart("imgFiles") List<MultipartFile> imgFiles
     ) {
         String email1 = "dlehdwls21@naver.com";
-        exerciseJournalService.exerciseJournalShare(journalId, email1, exerciseJournalShareRequest);
+        exerciseJournalService.exerciseJournalShare(journalId, email1, exerciseJournalShareRequest, imgFiles);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseJournalCompleteRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseJournalCompleteRequest.java
@@ -1,6 +1,6 @@
 package com.ogjg.daitgym.journal.dto.request;
 
-import com.ogjg.daitgym.domain.journal.TimeTemplate;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseJournalShareRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseJournalShareRequest.java
@@ -2,10 +2,6 @@ package com.ogjg.daitgym.journal.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -14,6 +10,4 @@ import static lombok.AccessLevel.PROTECTED;
 public class ExerciseJournalShareRequest {
     private boolean visible;
     private String split;
-    private List<MultipartFile> imgFiles = new ArrayList<>();
-
 }

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseListRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/ExerciseListRequest.java
@@ -1,6 +1,6 @@
 package com.ogjg.daitgym.journal.dto.request;
 
-import com.ogjg.daitgym.domain.journal.TimeTemplate;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ogjg/daitgym/journal/dto/request/UpdateRestTimeRequest.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/request/UpdateRestTimeRequest.java
@@ -1,6 +1,6 @@
 package com.ogjg.daitgym.journal.dto.request;
 
-import com.ogjg.daitgym.domain.journal.TimeTemplate;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ogjg/daitgym/journal/dto/response/dto/UserJournalDetailDto.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/response/dto/UserJournalDetailDto.java
@@ -1,7 +1,7 @@
 package com.ogjg.daitgym.journal.dto.response.dto;
 
 import com.ogjg.daitgym.domain.journal.ExerciseJournal;
-import com.ogjg.daitgym.domain.journal.TimeTemplate;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ogjg/daitgym/journal/dto/response/dto/UserJournalDetailExerciseListDto.java
+++ b/src/main/java/com/ogjg/daitgym/journal/dto/response/dto/UserJournalDetailExerciseListDto.java
@@ -1,7 +1,7 @@
 package com.ogjg.daitgym.journal.dto.response.dto;
 
 import com.ogjg.daitgym.domain.journal.ExerciseList;
-import com.ogjg.daitgym.domain.journal.TimeTemplate;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
@@ -14,6 +14,6 @@ public interface ExerciseJournalRepository extends JpaRepository<ExerciseJournal
 
     Optional<ExerciseJournal> findByJournalDateAndUser(LocalDate journalDate, User user);
 
-    int countByUserAndCompleted(User user, boolean completed);
+    int countByUserAndIsCompleted(User user, boolean completed);
 
 }

--- a/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
@@ -14,5 +14,6 @@ public interface ExerciseJournalRepository extends JpaRepository<ExerciseJournal
 
     Optional<ExerciseJournal> findByJournalDateAndUser(LocalDate journalDate, User user);
 
+    int countByUserAndCompleted(User user, boolean completed);
 
 }

--- a/src/main/java/com/ogjg/daitgym/journal/service/ExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/journal/service/ExerciseJournalService.java
@@ -24,11 +24,13 @@ import com.ogjg.daitgym.journal.exception.UserNotAuthorizedForJournal;
 import com.ogjg.daitgym.journal.repository.exercisehistory.ExerciseHistoryRepository;
 import com.ogjg.daitgym.journal.repository.exerciselist.ExerciseListRepository;
 import com.ogjg.daitgym.journal.repository.journal.ExerciseJournalRepository;
+
 import com.ogjg.daitgym.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -75,15 +77,15 @@ public class ExerciseJournalService {
     @Transactional
     public void exerciseJournalShare(
             Long journalId, String email,
-            ExerciseJournalShareRequest exerciseJournalShareRequest
+            ExerciseJournalShareRequest exerciseJournalShareRequest,
+            List<MultipartFile> imgFiles
     ) {
-        isAuthorizedForJournal(email, journalId);
-        ExerciseJournal exerciseJournal = findExerciseJournal(journalId);
+        ExerciseJournal exerciseJournal = isAuthorizedForJournal(email, journalId);
         exerciseJournal.journalShareToFeed(exerciseJournalShareRequest);
 
         if (exerciseJournal.isVisible()) {
             feedExerciseJournalService.shareJournalFeed(
-                    exerciseJournal, exerciseJournalShareRequest.getImgFiles()
+                    exerciseJournal, imgFiles
             );
         }
     }

--- a/src/main/java/com/ogjg/daitgym/like/feedExerciseJournal/repository/FeedExerciseJournalLikeRepository.java
+++ b/src/main/java/com/ogjg/daitgym/like/feedExerciseJournal/repository/FeedExerciseJournalLikeRepository.java
@@ -1,5 +1,6 @@
 package com.ogjg.daitgym.like.feedExerciseJournal.repository;
 
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournalLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ public interface FeedExerciseJournalLikeRepository extends JpaRepository<FeedExe
     int countByFeedJournalLikePkFeedExerciseJournalId(Long feedJournalId);
 
     boolean existsByUserEmailAndFeedExerciseJournalId(String email, Long feedJournalId);
+
+    void deleteAllByFeedExerciseJournal(FeedExerciseJournal feedExerciseJournal);
 }


### PR DESCRIPTION
### 피드 운동일지 삭제 구현
- [x] 피드 운동일지 삭제시 피드 이미지 삭제
- [x] 피드 운동일지 삭제시 피드 좋아요 삭제
- [x] 피드 운동일지 삭제시 피드 댓글 삭제
- [x] 피드 운동일지 삭제
- [x] 피드 운동일지 삭제후 운동일지 공개여부 변경

### 운동일지 공유시 피드 운동일지 생성
- [x] 운동일지 공유시 들어온 이미지 저장
- [x] 운동일지 공유시 피드운동일지 생성


---
### 운동완료한 운동일지 수 조회

### TimeTemplate 위치 변경

---
### 피드 운동일지 스크랩 추가

### ExerciseJournalRepository 버그 수정
- [ ] springDataJPA를 countByUserAndCompleted로 사용하여 빌드에러가 발생 -> countByUserAndIsCompleted로 변경

### 피드운동일지 삭제 후 공개여부 변경
- [ ] 메서드 이름 feedJournalDelete -> privateVisible 피드운동일지를 삭제하는 것보다 상태를 변경해주는 것이기 때문에 메서드 이름 변경