### PR TITLE
Feat : 피드 운동일지 기능 구현

### DIFF
--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode implements ErrorType {
     ALREADY_FOLLOW_USER(HttpStatus.NOT_FOUND, "404", "이미 팔로우한 유저입니다"),
     NOT_FOUND_FOLLOW(HttpStatus.NOT_FOUND, "404", "팔로우를 먼저 해주세요"),
     NOT_FOUND_EXERCISE(HttpStatus.NOT_FOUND, "404", "운동을 찾을 수 없습니다"),
+    NOT_FOUND_FEED_JOURNAL_IMAGE(HttpStatus.NOT_FOUND, "404", "운동일지 피드의 이미지를 찾을 수 없습니다"),
     NOT_FOUND_EXERCISE_PART(HttpStatus.NOT_FOUND, "404", "운동부위를 찾을 수 없습니다"),
     NOT_FOUND_EXERCISE_LIST(HttpStatus.NOT_FOUND, "404", "운동 목록을 찾을 수 없습니다"),
     NOT_FOUND_EXERCISE_HISTORY(HttpStatus.NOT_FOUND, "404", "운동 기록을 찾을 수 없습니다"),

--- a/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
+++ b/src/main/java/com/ogjg/daitgym/domain/journal/ExerciseJournal.java
@@ -70,7 +70,7 @@ public class ExerciseJournal extends BaseEntity {
         this.split = exerciseJournalShareRequest.getSplit();
     }
 
-    public void privateVisible() {
+    public void changeToPrivate() {
         this.isVisible = false;
     }
 

--- a/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
@@ -75,4 +75,20 @@ public class FeedExerciseJournalController {
 
         return new ApiResponse<>(ErrorCode.SUCCESS, feedLists);
     }
+
+    /**
+     * 팔로우 피드 목록 가져오기
+     */
+    @GetMapping("/follow")
+    public ApiResponse<List<FeedExerciseJournalListResponse>> getFollowFeedJournalLists(
+            //todo token useremail
+            String email,
+            @PageableDefault(page = 0, size = 12) Pageable pageable,
+            @ModelAttribute FeedSearchConditionRequest feedSearchConditionRequest
+    ) {
+        String email1 = "test@naver.com";
+        List<FeedExerciseJournalListResponse> followFeedLists = feedExerciseJournalService.followFeedJournalLists(email1, pageable, feedSearchConditionRequest);
+
+        return new ApiResponse<>(ErrorCode.SUCCESS, followFeedLists);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
@@ -6,6 +6,8 @@ import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalCountResponse;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalListResponse;
 import com.ogjg.daitgym.feed.service.FeedExerciseJournalService;
+import com.ogjg.daitgym.journal.dto.response.UserJournalDetailResponse;
+import com.ogjg.daitgym.journal.service.ExerciseJournalService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +23,7 @@ import java.util.List;
 public class FeedExerciseJournalController {
 
     private final FeedExerciseJournalService feedExerciseJournalService;
+    private final ExerciseJournalService exerciseJournalService;
 
     /**
      * 운동일지 피드 삭제
@@ -63,17 +66,17 @@ public class FeedExerciseJournalController {
     }
 
     /**
-     * 피드 목록 가져오기
+     * 피드 운동일지 목록 가져오기
      */
     @GetMapping
     public ApiResponse<List<FeedExerciseJournalListResponse>> getFeedJournalLists(
             @PageableDefault(page = 0, size = 12) Pageable pageable,
             @ModelAttribute FeedSearchConditionRequest feedSearchConditionRequest
     ) {
-        log.info(feedSearchConditionRequest.toString());
-        List<FeedExerciseJournalListResponse> feedLists = feedExerciseJournalService.feedExerciseJournalLists(pageable, feedSearchConditionRequest);
-
-        return new ApiResponse<>(ErrorCode.SUCCESS, feedLists);
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                feedExerciseJournalService.feedExerciseJournalLists(pageable, feedSearchConditionRequest)
+        );
     }
 
     /**
@@ -87,8 +90,22 @@ public class FeedExerciseJournalController {
             @ModelAttribute FeedSearchConditionRequest feedSearchConditionRequest
     ) {
         String email1 = "test@naver.com";
-        List<FeedExerciseJournalListResponse> followFeedLists = feedExerciseJournalService.followFeedJournalLists(email1, pageable, feedSearchConditionRequest);
-
-        return new ApiResponse<>(ErrorCode.SUCCESS, followFeedLists);
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                feedExerciseJournalService.followFeedJournalLists(email1, pageable, feedSearchConditionRequest)
+        );
     }
+
+    /**
+     * 피드 운동일지 상세보기
+     */
+    @GetMapping("{journalId}/journal-detail")
+    public ApiResponse<UserJournalDetailResponse> feedJournalDetail(
+            @PathVariable("journalId") Long journalId
+    ) {
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS, exerciseJournalService.JournalDetail(journalId)
+        );
+    }
+
 }

--- a/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
@@ -2,11 +2,17 @@ package com.ogjg.daitgym.feed.controller;
 
 import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalCountResponse;
+import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalListResponse;
 import com.ogjg.daitgym.feed.service.FeedExerciseJournalService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -54,5 +60,19 @@ public class FeedExerciseJournalController {
         String email1 = "dlehdwls21@naver.com";
         feedExerciseJournalService.feedExerciseJournalScrap(email1, feedJournalId);
         return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 피드 목록 가져오기
+     */
+    @GetMapping
+    public ApiResponse<List<FeedExerciseJournalListResponse>> getFeedJournalLists(
+            @PageableDefault(page = 0, size = 12) Pageable pageable,
+            @ModelAttribute FeedSearchConditionRequest feedSearchConditionRequest
+    ) {
+        log.info(feedSearchConditionRequest.toString());
+        List<FeedExerciseJournalListResponse> feedLists = feedExerciseJournalService.feedExerciseJournalLists(pageable, feedSearchConditionRequest);
+
+        return new ApiResponse<>(ErrorCode.SUCCESS, feedLists);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/FeedExerciseJournalController.java
@@ -3,6 +3,7 @@ package com.ogjg.daitgym.feed.controller;
 import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
 import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
+import com.ogjg.daitgym.feed.dto.response.FeedDetailResponse;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalCountResponse;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalListResponse;
 import com.ogjg.daitgym.feed.service.FeedExerciseJournalService;
@@ -100,7 +101,7 @@ public class FeedExerciseJournalController {
      * 피드 운동일지 상세보기
      */
     @GetMapping("{journalId}/journal-detail")
-    public ApiResponse<UserJournalDetailResponse> feedJournalDetail(
+    public ApiResponse<UserJournalDetailResponse> feedExerciseJournalDetail(
             @PathVariable("journalId") Long journalId
     ) {
         return new ApiResponse<>(
@@ -108,4 +109,21 @@ public class FeedExerciseJournalController {
         );
     }
 
+    /**
+     * 피드 상세보기
+     */
+    @GetMapping("{feedJournalId}/feed-details")
+    public ApiResponse<FeedDetailResponse> feedDetail(
+            @PathVariable("feedJournalId") Long feedJournalId,
+            //todo token useremail
+            String email
+
+    ) {
+        String email1 = "dlehdwls21@naver.com";
+
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                feedExerciseJournalService.feedDetail(feedJournalId, email1)
+        );
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/feed/controller/UserFeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/UserFeedExerciseJournalController.java
@@ -1,0 +1,35 @@
+package com.ogjg.daitgym.feed.controller;
+
+
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalListResponse;
+import com.ogjg.daitgym.feed.service.UserFeedExerciseJournalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feeds/user")
+public class UserFeedExerciseJournalController {
+
+    private final UserFeedExerciseJournalService userFeedExerciseJournalService;
+
+    @GetMapping("{nickname}")
+    public ApiResponse<List<FeedExerciseJournalListResponse>> userFeedExerciseJournalLists(
+            @PathVariable(name = "nickname") String nickname,
+            @PageableDefault(page = 0, size = 12) Pageable pageable
+    ) {
+        List<FeedExerciseJournalListResponse> feedExerciseJournalLists =
+                userFeedExerciseJournalService.userFeedExerciseJournalLists(nickname, pageable);
+
+        return new ApiResponse<>(ErrorCode.SUCCESS, feedExerciseJournalLists);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/controller/UserFeedExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/feed/controller/UserFeedExerciseJournalController.java
@@ -27,9 +27,21 @@ public class UserFeedExerciseJournalController {
             @PathVariable(name = "nickname") String nickname,
             @PageableDefault(page = 0, size = 12) Pageable pageable
     ) {
-        List<FeedExerciseJournalListResponse> feedExerciseJournalLists =
+        List<FeedExerciseJournalListResponse> userFeedExerciseJournalLists =
                 userFeedExerciseJournalService.userFeedExerciseJournalLists(nickname, pageable);
 
-        return new ApiResponse<>(ErrorCode.SUCCESS, feedExerciseJournalLists);
+        return new ApiResponse<>(ErrorCode.SUCCESS, userFeedExerciseJournalLists);
     }
+
+    @GetMapping("{nickname}/scrap")
+    public ApiResponse<List<FeedExerciseJournalListResponse>> userFeedExerciseJournalCollectionLists(
+            @PathVariable(name = "nickname") String nickname,
+            @PageableDefault(page = 0, size = 12) Pageable pageable
+    ) {
+        List<FeedExerciseJournalListResponse> userFeedExerciseJournalCollectionLists =
+                userFeedExerciseJournalService.userFeedExerciseJournalCollectionLists(nickname, pageable);
+
+        return new ApiResponse<>(ErrorCode.SUCCESS, userFeedExerciseJournalCollectionLists);
+    }
+
 }

--- a/src/main/java/com/ogjg/daitgym/feed/dto/request/FeedSearchConditionRequest.java
+++ b/src/main/java/com/ogjg/daitgym/feed/dto/request/FeedSearchConditionRequest.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.feed.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Setter
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FeedSearchConditionRequest {
+
+    private String split;
+    private List<String> part = new ArrayList<>();
+}

--- a/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedDetailResponse.java
+++ b/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedDetailResponse.java
@@ -1,0 +1,45 @@
+package com.ogjg.daitgym.feed.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FeedDetailResponse {
+
+    private Long feedId;
+    private String writer;
+    private String writerImg;
+    private LocalDateTime createdAt;
+    private boolean liked;
+    private int likeCounts;
+    private int scrapCounts;
+    private List<FeedImageDto> imageLists;
+
+    @QueryProjection
+    public FeedDetailResponse(
+            Long feedId, String writer,
+            String writerImg, LocalDateTime createdAt
+    ) {
+        this.feedId = feedId;
+        this.writer = writer;
+        this.writerImg = writerImg;
+        this.createdAt = createdAt;
+    }
+
+    public void setFeedDetails(
+            boolean liked, int likeCounts,
+            int scrapCounts, List<FeedImageDto> imageLists
+    ) {
+        this.liked = liked;
+        this.likeCounts = likeCounts;
+        this.scrapCounts = scrapCounts;
+        this.imageLists = imageLists;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedExerciseJournalListResponse.java
+++ b/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedExerciseJournalListResponse.java
@@ -1,0 +1,25 @@
+package com.ogjg.daitgym.feed.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FeedExerciseJournalListResponse {
+
+    private Long feedJournalId;
+    private int likes;
+    private int scrapCounts;
+    private String image;
+
+    public FeedExerciseJournalListResponse(
+            Long feedJournalId, int likes, int scrapCounts, String image
+    ) {
+        this.feedJournalId = feedJournalId;
+        this.likes = likes;
+        this.scrapCounts = scrapCounts;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedImageDto.java
+++ b/src/main/java/com/ogjg/daitgym/feed/dto/response/FeedImageDto.java
@@ -1,0 +1,18 @@
+package com.ogjg.daitgym.feed.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FeedImageDto {
+    private Long imageId;
+    private String imageUrl;
+
+    public FeedImageDto(Long imageId, String imageUrl) {
+        this.imageId = imageId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/exception/NotFoundFeedJournalImage.java
+++ b/src/main/java/com/ogjg/daitgym/feed/exception/NotFoundFeedJournalImage.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.feed.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundFeedJournalImage extends CustomException {
+    public NotFoundFeedJournalImage() {
+        super(ErrorCode.NOT_FOUND_FEED_JOURNAL_IMAGE);
+    }
+
+    public NotFoundFeedJournalImage(String message) {
+        super(ErrorCode.NOT_FOUND_FEED_JOURNAL_IMAGE, message);
+    }
+
+    public NotFoundFeedJournalImage(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_FEED_JOURNAL_IMAGE, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalCollectionRepository.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalCollectionRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedExerciseJournalCollectionRepository extends JpaRepository<FeedExerciseJournalCollection, Long> {
 
+    int countByPkFeedExerciseJournalId(Long feedJournalId);
 
 }

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalImageRepository.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalImageRepository.java
@@ -4,8 +4,11 @@ import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournalImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FeedExerciseJournalImageRepository extends JpaRepository<FeedExerciseJournalImage, Long> {
 
     void deleteAllByFeedExerciseJournal(FeedExerciseJournal feedExerciseJournal);
 
+    List<FeedExerciseJournalImage> findAllByFeedExerciseJournal(FeedExerciseJournal feedExerciseJournal);
 }

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface FeedExerciseJournalRepository extends JpaRepository<FeedExerciseJournal, Long> {
+public interface FeedExerciseJournalRepository extends JpaRepository<FeedExerciseJournal, Long>, FeedExerciseJournalRepositoryCustom {
 
     Optional<FeedExerciseJournal> findByExerciseJournal(ExerciseJournal exerciseJournal);
 

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
@@ -12,4 +12,6 @@ public interface FeedExerciseJournalRepositoryCustom {
     Page<FeedExerciseJournal> feedExerciseJournalListsByFollow(String email, Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest);
 
     Page<FeedExerciseJournal> userFeedExerciseJournalLists(String nickname, Pageable pageable);
+
+    Page<FeedExerciseJournal> userFeedExerciseJournalCollectionLists(String nickname, Pageable pageable);
 }

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
@@ -2,8 +2,11 @@ package com.ogjg.daitgym.feed.repository;
 
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
 import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
+import com.ogjg.daitgym.feed.dto.response.FeedDetailResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
 
 public interface FeedExerciseJournalRepositoryCustom {
 
@@ -14,4 +17,6 @@ public interface FeedExerciseJournalRepositoryCustom {
     Page<FeedExerciseJournal> userFeedExerciseJournalLists(String nickname, Pageable pageable);
 
     Page<FeedExerciseJournal> userFeedExerciseJournalCollectionLists(String nickname, Pageable pageable);
+
+    Optional<FeedDetailResponse> feedDetail(Long feedJournalId);
 }

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
@@ -11,4 +11,5 @@ public interface FeedExerciseJournalRepositoryCustom {
 
     Page<FeedExerciseJournal> feedExerciseJournalListsByFollow(String email, Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest);
 
+    Page<FeedExerciseJournal> userFeedExerciseJournalLists(String nickname, Pageable pageable);
 }

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.ogjg.daitgym.feed.repository;
+
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FeedExerciseJournalRepositoryCustom {
+
+    Page<FeedExerciseJournal> feedExerciseJournalLists(Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest);
+
+    Page<FeedExerciseJournal> feedExerciseJournalListsByFollow(String email, Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest);
+
+}

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryImpl.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.ogjg.daitgym.feed.repository;
 
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
 import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
+import com.ogjg.daitgym.feed.dto.response.FeedDetailResponse;
+import com.ogjg.daitgym.feed.dto.response.QFeedDetailResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -13,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.ogjg.daitgym.domain.QUser.user;
 import static com.ogjg.daitgym.domain.exercise.QExercise.exercise;
@@ -164,6 +167,30 @@ public class FeedExerciseJournalRepositoryImpl implements FeedExerciseJournalRep
                 .join(exerciseJournal).on(feedExerciseJournal.exerciseJournal.id.eq(exerciseJournal.id)).fetchJoin();
 
         return PageableExecutionUtils.getPage(userFeedJournalCollections, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 피드 운동일지 피드부분 상세보기
+     */
+    public Optional<FeedDetailResponse> feedDetail(
+            Long feedJournalId
+    ) {
+        FeedDetailResponse result = jpaQueryFactory
+                .select(
+                        new QFeedDetailResponse(
+                                feedExerciseJournal.id,
+                                user.nickname,
+                                user.imageUrl,
+                                feedExerciseJournal.createdAt
+                        )
+                )
+                .from(feedExerciseJournal)
+                .join(feedExerciseJournal.exerciseJournal, exerciseJournal)
+                .join(user).on(exerciseJournal.user.email.eq(user.email))
+                .where(feedExerciseJournal.id.eq(feedJournalId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 
 

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryImpl.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
+import static com.ogjg.daitgym.domain.QUser.user;
 import static com.ogjg.daitgym.domain.exercise.QExercise.exercise;
 import static com.ogjg.daitgym.domain.exercise.QExercisePart.exercisePart;
 import static com.ogjg.daitgym.domain.feed.QFeedExerciseJournal.feedExerciseJournal;
@@ -106,6 +107,38 @@ public class FeedExerciseJournalRepositoryImpl implements FeedExerciseJournalRep
 
         return PageableExecutionUtils.getPage(followerFeedJournalLists, pageable, countQuery::fetchOne);
     }
+
+    /**
+     * 피드 운동일지 상세보기
+     */
+
+
+    /**
+     * 유저 페이지 피드 운동일지 가져오기
+     */
+    public Page<FeedExerciseJournal> userFeedExerciseJournalLists(
+            String nickname, Pageable pageable
+    ) {
+        List<FeedExerciseJournal> userFeedJournalLists = jpaQueryFactory.select(feedExerciseJournal)
+                .from(user)
+                .where(user.nickname.eq(nickname))
+                .join(feedExerciseJournal).on(user.email.eq(feedExerciseJournal.exerciseJournal.user.email)).fetchJoin()
+                .orderBy(feedExerciseJournal.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory.select(feedExerciseJournal.count())
+                .from(user)
+                .where(user.nickname.eq(nickname))
+                .leftJoin(feedExerciseJournal).on(user.email.eq(feedExerciseJournal.exerciseJournal.user.email));
+
+        return PageableExecutionUtils.getPage(userFeedJournalLists, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 유저 페이지 피드 운동일지 컬렉션 가져오기
+     */
 
     /**
      * 운동 부위의 검색목록이 들어올시

--- a/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryImpl.java
+++ b/src/main/java/com/ogjg/daitgym/feed/repository/FeedExerciseJournalRepositoryImpl.java
@@ -1,0 +1,85 @@
+package com.ogjg.daitgym.feed.repository;
+
+
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.ogjg.daitgym.domain.exercise.QExercise.exercise;
+import static com.ogjg.daitgym.domain.exercise.QExercisePart.exercisePart;
+import static com.ogjg.daitgym.domain.feed.QFeedExerciseJournal.feedExerciseJournal;
+import static com.ogjg.daitgym.domain.journal.QExerciseJournal.exerciseJournal;
+import static com.ogjg.daitgym.domain.journal.QExerciseList.exerciseList;
+
+@RequiredArgsConstructor
+public class FeedExerciseJournalRepositoryImpl implements FeedExerciseJournalRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    /**
+     * 피드의 운동일지 전체 목록 검색 query
+     */
+    @Override
+    public Page<FeedExerciseJournal> feedExerciseJournalLists(
+            Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest
+    ) {
+        List<FeedExerciseJournal> journalLists = jpaQueryFactory.select(
+                        feedExerciseJournal
+                ).from(feedExerciseJournal)
+                .leftJoin(feedExerciseJournal.exerciseJournal, exerciseJournal).fetchJoin()
+                .leftJoin(exerciseList).on(exerciseJournal.id.eq(exerciseList.exerciseJournal.id)).fetchJoin()
+                .leftJoin(exercise).on(exerciseList.exercise.id.eq(exercise.id)).fetchJoin()
+                .leftJoin(exercisePart).on(exercise.id.eq(exercisePart.exercise.id)).fetchJoin()
+                .where(
+                        feedExerciseJournal.exerciseJournal.split.eq(feedSearchConditionRequest.getSplit()),
+                        exercisePartEq(feedSearchConditionRequest.getPart(), exercisePart.part)
+                ).orderBy(feedExerciseJournal.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+
+        JPAQuery<Long> countQuery = jpaQueryFactory.select(feedExerciseJournal.count())
+                .from(feedExerciseJournal)
+                .leftJoin(feedExerciseJournal.exerciseJournal, exerciseJournal)
+                .leftJoin(exerciseList).on(exerciseJournal.id.eq(exerciseList.exerciseJournal.id))
+                .leftJoin(exercise).on(exerciseList.exercise.id.eq(exercise.id))
+                .leftJoin(exercisePart).on(exercise.id.eq(exercisePart.exercise.id))
+                .where(
+                        feedExerciseJournal.exerciseJournal.split.eq(feedSearchConditionRequest.getSplit()),
+                        exercisePartEq(feedSearchConditionRequest.getPart(), exercisePart.part)
+                );
+
+        return PageableExecutionUtils.getPage(journalLists, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<FeedExerciseJournal> feedExerciseJournalListsByFollow(
+            String email, Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest
+    ) {
+        return null;
+    }
+
+    /**
+     * 운동 부위의 검색목록이 들어올시
+     * or문으로 연산이 실행 검색목록이 빈배열시
+     * null을 반환하며 실행안됌
+     */
+    private BooleanExpression exercisePartEq(List<String> parts, StringPath queryPart) {
+        if (parts == null) return null;
+
+        return parts.stream()
+                .map(queryPart::eq)
+                .reduce(BooleanExpression::or)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -71,7 +72,8 @@ public class FeedExerciseJournalService {
     public List<FeedExerciseJournalListResponse> feedExerciseJournalLists(
             Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest
     ) {
-        Page<FeedExerciseJournal> feedExerciseJournals = feedExerciseJournalRepository.feedExerciseJournalLists(pageable, feedSearchConditionRequest);
+        Page<FeedExerciseJournal> feedExerciseJournals = feedExerciseJournalRepository
+                .feedExerciseJournalLists(pageable, feedSearchConditionRequest);
 
         return feedExerciseJournals.getContent()
                 .stream()
@@ -79,9 +81,27 @@ public class FeedExerciseJournalService {
                         feedExerciseJournal.getId(),
                         feedExerciseJournalLikes(feedExerciseJournal.getId()),
                         feedExerciseJournalScrapCounts(feedExerciseJournal.getId()),
-                        findFeedExerciseJournalImageByFeedExerciseJournal(feedExerciseJournal).get(0).getImageUrl()
-                ))
-                .toList();
+                        findFeedExerciseJournalImagesByFeedExerciseJournal(feedExerciseJournal).get(0).getImageUrl()
+                )).collect(Collectors.toList());
+    }
+
+    /**
+     * 팔로우 피드 운동일지 가져오기 목록보기 무한 스크롤
+     * 분할 및 부위 분할 및 부위로 검색가능
+     */
+    public List<FeedExerciseJournalListResponse> followFeedJournalLists(
+            String email, Pageable pageable, FeedSearchConditionRequest feedSearchConditionRequest
+    ) {
+        Page<FeedExerciseJournal> feedExerciseJournals = feedExerciseJournalRepository
+                .feedExerciseJournalListsByFollow(email, pageable, feedSearchConditionRequest);
+
+        return feedExerciseJournals.getContent().stream()
+                .map(feedExerciseJournal -> new FeedExerciseJournalListResponse(
+                        feedExerciseJournal.getId(),
+                        feedExerciseJournalLikes(feedExerciseJournal.getId()),
+                        feedExerciseJournalScrapCounts(feedExerciseJournal.getId()),
+                        findFeedExerciseJournalImagesByFeedExerciseJournal(feedExerciseJournal).get(0).getImageUrl()
+                )).collect(Collectors.toList());
     }
 
     /**
@@ -101,18 +121,12 @@ public class FeedExerciseJournalService {
     /**
      * 피드운동일지 이미지 가져오기
      */
-    private List<FeedExerciseJournalImage> findFeedExerciseJournalImageByFeedExerciseJournal(
+    private List<FeedExerciseJournalImage> findFeedExerciseJournalImagesByFeedExerciseJournal(
             FeedExerciseJournal feedExerciseJournal
     ) {
         return feedExerciseJournalImageRepository.findAllByFeedExerciseJournal(feedExerciseJournal);
     }
 
-
-    /**
-     * 피드 운동일지 가져오기 목록보기 무한 스크롤
-     * 분할 및 부위 분할 및 부위로 검색가능
-     * 팔로우 => ?
-     */
 
     /**
      * 피드 운동일지 상세정보 가져오기

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
@@ -8,8 +8,10 @@ import com.ogjg.daitgym.domain.feed.FeedExerciseJournalCollection;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournalImage;
 import com.ogjg.daitgym.domain.journal.ExerciseJournal;
 import com.ogjg.daitgym.feed.dto.request.FeedSearchConditionRequest;
+import com.ogjg.daitgym.feed.dto.response.FeedDetailResponse;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalCountResponse;
 import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalListResponse;
+import com.ogjg.daitgym.feed.dto.response.FeedImageDto;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalCollectionRepository;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalImageRepository;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalRepository;
@@ -181,6 +183,33 @@ public class FeedExerciseJournalService {
      * todo
      * 피드 운동일지 상세정보 가져오기
      */
+    public FeedDetailResponse feedDetail(
+            Long feedJournalId, String email
+    ) {
+        FeedDetailResponse feedDetail = feedExerciseJournalRepository.feedDetail(feedJournalId)
+                .orElseThrow(NotFoundFeedJournal::new);
+
+        feedDetail.setFeedDetails(
+                feedExerciseJournalLikeRepository.existsByUserEmailAndFeedExerciseJournalId(email, feedJournalId),
+                feedExerciseJournalLikes(feedJournalId),
+                feedExerciseJournalScrapCounts(feedJournalId),
+                feedImageListsDto(feedJournalHelperService.findFeedJournalById(feedJournalId))
+        );
+
+        return feedDetail;
+    }
+
+    /**
+     * 피드 이미지목록 Dto로 변환
+     */
+    private List<FeedImageDto> feedImageListsDto(FeedExerciseJournal feedExerciseJournal){
+        return findFeedExerciseJournalImagesByFeedExerciseJournal(feedExerciseJournal)
+                .stream()
+                .map(feedExerciseJournalImage -> new FeedImageDto(
+                        feedExerciseJournalImage.getId(), feedExerciseJournalImage.getImageUrl())
+                )
+                .toList();
+    }
 
     /**
      * 운동일지로 피드 운동일지 찾기

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
@@ -128,18 +128,6 @@ public class FeedExerciseJournalService {
     }
 
     /**
-     * 피드 운동일지 상세정보 가져오기
-     */
-
-    /**
-     * 피드 운동일지 보관함 조회 목록보기
-     */
-
-    /**
-     * 사용자 피드 운동일지 목록 조회
-     */
-
-    /**
      * 피드 운동일지 스크랩
      */
     public void feedExerciseJournalScrap(
@@ -188,6 +176,11 @@ public class FeedExerciseJournalService {
                 exerciseJournalRepository.countByUserAndIsCompleted(user, true)
         );
     }
+
+    /**
+     * todo
+     * 피드 운동일지 상세정보 가져오기
+     */
 
     /**
      * 운동일지로 피드 운동일지 찾기

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedExerciseJournalService.java
@@ -162,7 +162,7 @@ public class FeedExerciseJournalService {
 
         feedExerciseJournalRepository.delete(feedJournal);
 
-        feedJournal.getExerciseJournal().privateVisible();
+        feedJournal.getExerciseJournal().changeToPrivate();
     }
 
     /**

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedJournalHelperService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedJournalHelperService.java
@@ -1,0 +1,39 @@
+package com.ogjg.daitgym.feed.service;
+
+
+import com.ogjg.daitgym.comment.feedExerciseJournal.exception.NotFoundFeedJournal;
+import com.ogjg.daitgym.domain.User;
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.feed.repository.FeedExerciseJournalRepository;
+import com.ogjg.daitgym.user.exception.NotFoundUser;
+import com.ogjg.daitgym.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedJournalHelperService {
+
+    private final FeedExerciseJournalRepository feedExerciseJournalRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * Id로 feedJournal 검색
+     */
+    public FeedExerciseJournal findFeedJournalById(Long feedJournalId) {
+        return feedExerciseJournalRepository.findById(feedJournalId)
+                .orElseThrow(NotFoundFeedJournal::new);
+    }
+
+    public User findUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
+                .orElseThrow(NotFoundUser::new);
+    }
+
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(NotFoundUser::new);
+    }
+
+
+}

--- a/src/main/java/com/ogjg/daitgym/feed/service/UserFeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/UserFeedExerciseJournalService.java
@@ -20,6 +20,9 @@ public class UserFeedExerciseJournalService {
     private final FeedExerciseJournalService feedExerciseJournalService;
     private final FeedJournalHelperService feedJournalHelperService;
 
+    /**
+     * 유저 페이지 피드 운동일지 목록 가져오기
+     */
     public List<FeedExerciseJournalListResponse> userFeedExerciseJournalLists(
             String nickname, Pageable pageable
     ) {
@@ -27,6 +30,26 @@ public class UserFeedExerciseJournalService {
 
         return userFeedExerciseJournals.getContent()
                 .stream().map(
+                        feedExerciseJournal -> new FeedExerciseJournalListResponse(
+                                feedExerciseJournal.getId(),
+                                feedExerciseJournalService.feedExerciseJournalLikes(feedExerciseJournal.getId()),
+                                feedExerciseJournalService.feedExerciseJournalScrapCounts(feedExerciseJournal.getId()),
+                                feedExerciseJournalService.findFeedExerciseJournalImagesByFeedExerciseJournal(feedExerciseJournal).get(0).getImageUrl()
+                        )
+                ).toList();
+    }
+
+    /**
+     * 피드 운동일지 보관함 조회 목록보기
+     */
+    public List<FeedExerciseJournalListResponse> userFeedExerciseJournalCollectionLists(
+            String nickname, Pageable pageable
+    ) {
+        Page<FeedExerciseJournal> userFeedJournalCollections = feedExerciseJournalRepository.userFeedExerciseJournalCollectionLists(nickname, pageable);
+
+        return userFeedJournalCollections.getContent()
+                .stream()
+                .map(
                         feedExerciseJournal -> new FeedExerciseJournalListResponse(
                                 feedExerciseJournal.getId(),
                                 feedExerciseJournalService.feedExerciseJournalLikes(feedExerciseJournal.getId()),

--- a/src/main/java/com/ogjg/daitgym/feed/service/UserFeedExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/UserFeedExerciseJournalService.java
@@ -1,0 +1,38 @@
+package com.ogjg.daitgym.feed.service;
+
+import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.feed.dto.response.FeedExerciseJournalListResponse;
+import com.ogjg.daitgym.feed.repository.FeedExerciseJournalRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserFeedExerciseJournalService {
+
+    private final FeedExerciseJournalRepository feedExerciseJournalRepository;
+    private final FeedExerciseJournalService feedExerciseJournalService;
+    private final FeedJournalHelperService feedJournalHelperService;
+
+    public List<FeedExerciseJournalListResponse> userFeedExerciseJournalLists(
+            String nickname, Pageable pageable
+    ) {
+        Page<FeedExerciseJournal> userFeedExerciseJournals = feedExerciseJournalRepository.userFeedExerciseJournalLists(nickname, pageable);
+
+        return userFeedExerciseJournals.getContent()
+                .stream().map(
+                        feedExerciseJournal -> new FeedExerciseJournalListResponse(
+                                feedExerciseJournal.getId(),
+                                feedExerciseJournalService.feedExerciseJournalLikes(feedExerciseJournal.getId()),
+                                feedExerciseJournalService.feedExerciseJournalScrapCounts(feedExerciseJournal.getId()),
+                                feedExerciseJournalService.findFeedExerciseJournalImagesByFeedExerciseJournal(feedExerciseJournal).get(0).getImageUrl()
+                        )
+                ).toList();
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
@@ -190,7 +190,7 @@ public class ExerciseJournalController {
             String email,
             @PathVariable("journalId") Long journalId,
             @RequestPart("share") ExerciseJournalShareRequest exerciseJournalShareRequest,
-            @RequestPart("imgFiles") List<MultipartFile> imgFiles
+            @RequestPart(value = "imgFiles", required = false) List<MultipartFile> imgFiles
     ) {
         String email1 = "dlehdwls21@naver.com";
         exerciseJournalService.exerciseJournalShare(journalId, email1, exerciseJournalShareRequest, imgFiles);

--- a/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
+++ b/src/main/java/com/ogjg/daitgym/journal/controller/ExerciseJournalController.java
@@ -140,7 +140,7 @@ public class ExerciseJournalController {
     /**
      * 내 운동일지 상세보기
      */
-    @GetMapping("{journalDate}")
+    @GetMapping("/{journalDate}")
     public ApiResponse<UserJournalDetailResponse> userJournalDetail(
 //      todo email 가져오기
             String email,

--- a/src/main/java/com/ogjg/daitgym/journal/service/ExerciseJournalService.java
+++ b/src/main/java/com/ogjg/daitgym/journal/service/ExerciseJournalService.java
@@ -91,6 +91,14 @@ public class ExerciseJournalService {
     }
 
     /**
+     * 운동일지 공개여부 확인
+     * */
+    private void checkDisclosure(Long journalId){
+        if (!findExerciseJournal(journalId).isVisible())
+            throw new UserNotAuthorizedForJournal("공개된 운동일지가 아닙니다");
+    }
+
+    /**
      * 운동 목록 휴식시간 변경
      */
     @Transactional
@@ -239,6 +247,25 @@ public class ExerciseJournalService {
     ) {
         ExerciseJournal exerciseJournal = findExerciseJournalByUserAndJournalDate(findUserByEmail(email), journalDate);
         isAuthorizedForJournal(email, exerciseJournal.getId());
+
+        List<ExerciseList> journalList = findExerciseListByJournal(exerciseJournal);
+        List<UserJournalDetailExerciseListDto> exerciseListDtos = userJournalDetailExerciseListDtos(journalList);
+        UserJournalDetailDto userJournalDetailDto = new UserJournalDetailDto(exerciseJournal, exerciseListDtos);
+
+        return new UserJournalDetailResponse(userJournalDetailDto);
+    }
+
+    /**
+     * todo 구조적 개선할 필요성이 있어보임 순환참조 가능성
+     * 피드 운동일지 상세보기
+     * 공개여부 확인후 운동일지 반환
+     */
+    @Transactional(readOnly = true)
+    public UserJournalDetailResponse JournalDetail(
+            Long journalId
+    ) {
+        checkDisclosure(journalId);
+        ExerciseJournal exerciseJournal = findExerciseJournal(journalId);
 
         List<ExerciseList> journalList = findExerciseListByJournal(exerciseJournal);
         List<UserJournalDetailExerciseListDto> exerciseListDtos = userJournalDetailExerciseListDtos(journalList);


### PR DESCRIPTION
### [Feat : DIG-90 피드 운동일지 전체 조회 구현]

- ### 피드 운동일지 전체 조회

- [ ] 피드 12개씩 페이징
- [ ] 해당하는 분할의 일지만 조회
- [ ] 운동부위를 요청받으면 해당하는 운동부위에 관한 일지 검색가능
- [ ] 피드 생성일자 기준으로 정렬
- [ ] 대표 이미지 한개만 반환

---

### [Feat : DIG-91 피드 운동일지 팔로우 조회 구현]
- ### 팔로우 피드 운동일지 전체 조회
- [ ] 피드 12개씩 페이징
- [ ] 해당하는 분할의 일지만 조회
- [ ] 운동부위를 요청받으면 해당하는 운동부위에 관한 일지 검색가능
- [ ] 피드 생성일자 기준으로 정렬
- [ ] 대표 이미지 한개만 반환
- [ ] 팔로우한 유저들의 피드만 조회

---

### [Feat : DIG-93 마이페이지 유저 피드 운동일지 조회 구현, HelperServiceClass로 공통로직 분리]
- ### 마이페이지 유저 피드 운동일지 조회 구현
- [ ] 피드 12개씩 페이징
- [ ] 피드 생성일자 기준으로 정렬
- [ ] 대표 이미지 한개만 반환
- ### HelperServiceClass로 공통로직 분리

---

### [Feat : DIG-94 마이페이지 유저 피드 운동일지 스크랩 목록 가져오기]

- ### 마이페이지 유저 피드 운동일지 스크랩 목록 조회
- [ ] 피드 12개씩 페이징
- [ ] 피드 생성일자 기준으로 정렬
- [ ] 대표 이미지 한개만 반환

---

### [Feat : DIG-95 피드 운동일지 상세보기]

- ### 피드 운동일지 상세보기 조회
- [ ] 공유된 일지인지 확인

---

### [Feat : DIG-98 피드 운동일지 상세보기]

- ### 피드 운동일지 상세보기 피드 부분 상세보기

