### PR TITLE
루틴 API 구현 및 변경(작성, 삭제, 스크랩)

### DIFF
--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode implements ErrorType {
     NO_EXERCISE_IN_ROUTINE(HttpStatus.NOT_FOUND, "404", "루틴의 운동을 찾을 수 없습니다."),
     REFRESH_TOKEN_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "401", "Refresh Token 인증 오류"),
     ACCESS_TOKEN_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "401", "Access Token 인증 오류"),
+    NOT_FOUND_SCRAPED_USER_ROUTINE(HttpStatus.NOT_FOUND, "404", "스크랩 된 유저의 루틴을 찾을 수 없습니다."),
 
     UNAUTHORIZED_USER_ACCESS(HttpStatus.FORBIDDEN, "403", "접근 권한이 부족합니다.")
     ;

--- a/src/main/java/com/ogjg/daitgym/domain/TimeTemplate.java
+++ b/src/main/java/com/ogjg/daitgym/domain/TimeTemplate.java
@@ -23,4 +23,10 @@ public class TimeTemplate {
         this.minutes = timeTemplate.getMinutes();
         this.seconds = timeTemplate.getSeconds();
     }
+
+    public TimeTemplate(int hours, int minutes, int seconds) {
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/routine/Day.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/Day.java
@@ -1,6 +1,7 @@
 package com.ogjg.daitgym.domain.routine;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,9 +24,20 @@ public class Day {
     @JoinColumn(name = "routine_id")
     private Routine routine;
 
-    @OneToMany(mappedBy = "day", fetch = LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "day", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ExerciseDetail> exerciseDetails;
 
     private int dayNumber;
 
+    @Builder
+    public Day(Routine routine, List<ExerciseDetail> exerciseDetails, int dayNumber) {
+        this.routine = routine;
+        this.exerciseDetails = exerciseDetails;
+        this.dayNumber = dayNumber;
+    }
+
+    public void addExerciseDetail(ExerciseDetail exerciseDetail) {
+        this.exerciseDetails.add(exerciseDetail);
+        exerciseDetail.setDay(this);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/routine/ExerciseDetail.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/ExerciseDetail.java
@@ -1,13 +1,12 @@
 package com.ogjg.daitgym.domain.routine;
 
 import com.ogjg.daitgym.domain.BaseEntity;
+import com.ogjg.daitgym.domain.TimeTemplate;
 import com.ogjg.daitgym.domain.exercise.Exercise;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalTime;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -38,10 +37,10 @@ public class ExerciseDetail extends BaseEntity {
 
     private int exerciseOrder;
 
-    private LocalTime restTime;
+    private TimeTemplate restTime;
 
     @Builder
-    public ExerciseDetail(Day day, Exercise exercise, int setCount, int repetitionCount, int weight, int exerciseOrder, LocalTime restTime) {
+    public ExerciseDetail(Day day, Exercise exercise, int setCount, int repetitionCount, int weight, int exerciseOrder, TimeTemplate restTime) {
         this.day = day;
         this.exercise = exercise;
         this.setCount = setCount;
@@ -49,5 +48,9 @@ public class ExerciseDetail extends BaseEntity {
         this.weight = weight;
         this.exerciseOrder = exerciseOrder;
         this.restTime = restTime;
+    }
+
+    public void setDay(Day day) {
+        this.day = day;
     }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
@@ -53,10 +53,6 @@ public class Routine extends BaseEntity {
     @OneToMany(mappedBy = "routine", cascade = ALL, orphanRemoval = true)
     private List<UserRoutineCollection> userRoutineCollections = new ArrayList<>();
 
-    public int getLikesCount() {
-        return routineLikes.size();
-    }
-
     @Builder
     public Routine(User user, Routine originalRoutine, String title, String content, int duration, int division) {
         this.user = user;

--- a/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
@@ -8,9 +8,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -46,6 +49,9 @@ public class Routine extends BaseEntity {
 
     @OneToMany(mappedBy = "routine", fetch = LAZY)
     private Set<RoutineLike> routineLikes = new HashSet<>();
+
+    @OneToMany(mappedBy = "routine", cascade = ALL, orphanRemoval = true)
+    private List<UserRoutineCollection> userRoutineCollections = new ArrayList<>();
 
     public int getLikesCount() {
         return routineLikes.size();

--- a/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
@@ -4,6 +4,7 @@ import com.ogjg.daitgym.domain.BaseEntity;
 import com.ogjg.daitgym.domain.UnitType;
 import com.ogjg.daitgym.domain.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -48,5 +49,15 @@ public class Routine extends BaseEntity {
 
     public int getLikesCount() {
         return routineLikes.size();
+    }
+
+    @Builder
+    public Routine(User user, Routine originalRoutine, String title, String content, int duration, int division) {
+        this.user = user;
+        this.originalRoutine = originalRoutine;
+        this.title = title;
+        this.content = content;
+        this.duration = duration;
+        this.division = division;
     }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/routine/UserRoutineCollection.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/UserRoutineCollection.java
@@ -1,0 +1,53 @@
+package com.ogjg.daitgym.domain.routine;
+
+import com.ogjg.daitgym.domain.BaseEntity;
+import com.ogjg.daitgym.domain.User;
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class UserRoutineCollection extends BaseEntity {
+
+    @EmbeddedId
+    private PK pk;
+
+    @MapsId("email")
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "email")
+    private User user;
+
+    @MapsId("routine")
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "routine_id")
+    private Routine routine;
+
+    public UserRoutineCollection(User user,
+                                 Routine routine) {
+        this.pk = new PK(user.getEmail(), routine.getId());
+        this.user = user;
+        this.routine = routine;
+    }
+
+    @Getter
+    @Embeddable
+    @EqualsAndHashCode
+    @NoArgsConstructor(access = PROTECTED)
+    public static class PK implements Serializable {
+        private String email;
+        private Long routineId;
+
+        public PK(String email, Long routineId) {
+            this.email = email;
+            this.routineId = routineId;
+        }
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/domain/routine/UserRoutineCollection.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/UserRoutineCollection.java
@@ -25,7 +25,7 @@ public class UserRoutineCollection extends BaseEntity {
     @JoinColumn(name = "email")
     private User user;
 
-    @MapsId("routine")
+    @MapsId("routineId")
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "routine_id")
     private Routine routine;

--- a/src/main/java/com/ogjg/daitgym/like/routine/repository/RoutineLikeRepository.java
+++ b/src/main/java/com/ogjg/daitgym/like/routine/repository/RoutineLikeRepository.java
@@ -3,6 +3,7 @@ package com.ogjg.daitgym.like.routine.repository;
 import com.ogjg.daitgym.domain.routine.RoutineLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Set;
 
@@ -13,5 +14,8 @@ public interface RoutineLikeRepository extends JpaRepository<RoutineLike, Long> 
 
     @Query("SELECT rl.routine.id FROM RoutineLike rl WHERE rl.user.email = :email")
     Set<Long> findLikedRoutineIdByUserEmail(String email);
+
+    @Query("SELECT COUNT(rl) FROM RoutineLike rl WHERE rl.routine.id = :routineId")
+    long countByRoutineId(@Param("routineId") Long routineId);
 
 }

--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -5,6 +5,7 @@ import com.ogjg.daitgym.common.response.ApiResponse;
 import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
 import com.ogjg.daitgym.routine.dto.RoutineDetailsResponseDto;
 import com.ogjg.daitgym.routine.dto.RoutineListResponseDto;
+import com.ogjg.daitgym.routine.dto.RoutineRequestDto;
 import com.ogjg.daitgym.routine.service.RoutineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,5 +61,15 @@ public class RoutineController {
         RoutineDetailsResponseDto routineDetails = routineService.getRoutineDetails(routineId, oAuth2JwtUserDetails.getEmail());
 
         return new ApiResponse<>(ErrorCode.SUCCESS, routineDetails);
+    }
+
+    @PostMapping
+    public ApiResponse<Void> createRoutine(
+            @RequestBody RoutineRequestDto routineRequestDto,
+            @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {
+
+        routineService.createRoutine(routineRequestDto, oAuth2JwtUserDetails.getEmail());
+
+        return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -72,4 +72,13 @@ public class RoutineController {
 
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
+
+    @DeleteMapping("/{routineId}")
+    public ApiResponse<Void> deleteRoutine(
+            @PathVariable("routineId") Long routineId,
+            @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {
+        routineService.deleteRoutine(routineId, oAuth2JwtUserDetails.getEmail());
+
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -99,4 +99,14 @@ public class RoutineController {
 
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
+
+    @GetMapping("/scraps")
+    public ApiResponse<RoutineListResponseDto> getScrapedRoutines(
+            Pageable pageable,
+            @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails
+    ) {
+        RoutineListResponseDto scrapedRoutines = routineService.getScrapedRoutines(oAuth2JwtUserDetails.getEmail(), pageable);
+
+        return new ApiResponse<>(ErrorCode.SUCCESS, scrapedRoutines);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -90,4 +90,13 @@ public class RoutineController {
 
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
+
+    @DeleteMapping("/scrap/{routineId}")
+    public ApiResponse<Void> unscrapRoutine(
+            @PathVariable("routineId") Long routineId,
+            @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {
+        routineService.unscrapRoutine(routineId, oAuth2JwtUserDetails.getEmail());
+
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -81,4 +81,13 @@ public class RoutineController {
 
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
+
+    @GetMapping("/scrap/{routineId}")
+    public ApiResponse<Void> scrapRoutine(
+            @PathVariable("routineId") Long routineId,
+            @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {
+        routineService.scrapRoutine(routineId, oAuth2JwtUserDetails.getEmail());
+
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDetailsResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDetailsResponseDto.java
@@ -13,12 +13,12 @@ public class RoutineDetailsResponseDto {
     private String title;
     private String description;
     private boolean liked;
-    private int likeCounts;
-    private int scrapCounts;
+    private long likeCounts;
+    private long scrapCounts;
     private RoutineDto routine;
 
     @Builder
-    public RoutineDetailsResponseDto(String writer, String writerImg, LocalDateTime createdAt, String title, String description, boolean liked, int likeCounts, int scrapCounts, RoutineDto routine) {
+    public RoutineDetailsResponseDto(String writer, String writerImg, LocalDateTime createdAt, String title, String description, boolean liked, long likeCounts, long scrapCounts, RoutineDto routine) {
         this.writer = writer;
         this.writerImg = writerImg;
         this.createdAt = createdAt;

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
@@ -11,12 +11,12 @@ public class RoutineDto {
     private String author;
     private String description;
     private boolean liked;
-    private int likeCounts;
-    private int scrapCounts;
+    private long likeCounts;
+    private long scrapCounts;
     private LocalDateTime createdAt;
 
     @Builder
-    public RoutineDto(Long id, String title, String author, String description, boolean liked, int likeCounts, int scrapCounts, LocalDateTime createdAt) {
+    public RoutineDto(Long id, String title, String author, String description, boolean liked, long likeCounts, long scrapCounts, LocalDateTime createdAt) {
         this.id = id;
         this.title = title;
         this.author = author;

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineRequestDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineRequestDto.java
@@ -1,0 +1,65 @@
+package com.ogjg.daitgym.routine.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RoutineRequestDto {
+    private String title;
+    private String description;
+    private int division;
+    private RoutineDto routine;
+
+    @Getter
+    public class RoutineDto {
+        private Long id;
+        private List<DayDto> days;
+    }
+
+    @Getter
+    public class DayDto {
+        private Long id;
+        private int order;
+        private long dayDate;
+        private ExerciseTimeDto exerciseTime;
+        private boolean completed;
+        private boolean spread;
+        private List<ExerciseDto> exercises;
+    }
+
+    @Getter
+    public class ExerciseDto {
+        private Long id;
+        private int order;
+        private String name;
+        private String part;
+        private RestTimeDto restTime;
+        private boolean spread;
+        private List<ExerciseSetDto> exerciseSets;
+    }
+
+    @Getter
+    public class ExerciseSetDto {
+        private Long id;
+        private int order;
+        private int weights;
+        private int counts;
+        private boolean completed;
+    }
+
+    @Getter
+    public class RestTimeDto {
+        private int hours;
+        private int minutes;
+        private int seconds;
+    }
+
+    @Getter
+    public class ExerciseTimeDto {
+        private int hours;
+        private int minutes;
+        private int seconds;
+    }
+}
+

--- a/src/main/java/com/ogjg/daitgym/routine/exception/NotFoundScrapedUserRoutine.java
+++ b/src/main/java/com/ogjg/daitgym/routine/exception/NotFoundScrapedUserRoutine.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.routine.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundScrapedUserRoutine extends CustomException {
+    public NotFoundScrapedUserRoutine() {
+        super(ErrorCode.NOT_FOUND_SCRAPED_USER_ROUTINE);
+    }
+
+    public NotFoundScrapedUserRoutine(String message) {
+        super(ErrorCode.NOT_FOUND_SCRAPED_USER_ROUTINE, message);
+    }
+
+    public NotFoundScrapedUserRoutine(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_SCRAPED_USER_ROUTINE, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/RoutineRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface RoutineRepository extends JpaRepository<Routine, String> {
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division)")
     Optional<Slice<Routine>> findAllByDivision(@Param("division") Integer division, Pageable pageable);
@@ -21,6 +21,6 @@ public interface RoutineRepository extends JpaRepository<Routine, String> {
     @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division) AND r.user.email IN :followerEmails")
     Optional<Slice<Routine>> findByDivisionAndUserEmailIn(@Param("division") Integer division, @Param("followerEmails") List<String> followerEmails, Pageable pageable);
 
-    Optional<Routine> findById(Long routineId);
+//    Optional<Routine> findById(Long routineId);
 
 }

--- a/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
@@ -1,0 +1,9 @@
+package com.ogjg.daitgym.routine.repository;
+
+import com.ogjg.daitgym.domain.routine.UserRoutineCollection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import static com.ogjg.daitgym.domain.routine.UserRoutineCollection.*;
+
+public interface UserRoutineCollectionRepository extends JpaRepository<UserRoutineCollection, PK> {
+}

--- a/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
@@ -1,9 +1,18 @@
 package com.ogjg.daitgym.routine.repository;
 
+import com.ogjg.daitgym.domain.routine.Routine;
 import com.ogjg.daitgym.domain.routine.UserRoutineCollection;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import static com.ogjg.daitgym.domain.routine.UserRoutineCollection.*;
 
 public interface UserRoutineCollectionRepository extends JpaRepository<UserRoutineCollection, PK> {
+
+    @Query("SELECT urc.routine FROM UserRoutineCollection urc WHERE urc.pk.email = :email")
+    Slice<Routine> findRoutinesByUserEmail(@Param("email") String email, Pageable pageable);
+
 }

--- a/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
@@ -15,4 +15,6 @@ public interface UserRoutineCollectionRepository extends JpaRepository<UserRouti
     @Query("SELECT urc.routine FROM UserRoutineCollection urc WHERE urc.pk.email = :email")
     Slice<Routine> findRoutinesByUserEmail(@Param("email") String email, Pageable pageable);
 
+    @Query("SELECT COUNT(urc) FROM UserRoutineCollection urc WHERE urc.pk.routineId = :routineId")
+    long countByRoutineId(@Param("routineId") Long routineId);
 }

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -18,6 +18,7 @@ import com.ogjg.daitgym.routine.repository.DayRepository;
 import com.ogjg.daitgym.routine.repository.ExerciseDetailRepository;
 import com.ogjg.daitgym.routine.repository.RoutineRepository;
 import com.ogjg.daitgym.user.exception.NotFoundUser;
+import com.ogjg.daitgym.user.exception.UnauthorizedUser;
 import com.ogjg.daitgym.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -210,5 +211,17 @@ public class RoutineService {
                 });
             });
         });
+    }
+
+    @Transactional
+    public void deleteRoutine(Long routineId, String email) {
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(NotFoundRoutine::new);
+
+        if (!routine.getUser().getEmail().equals(email)) {
+            throw new UnauthorizedUser("사용자에게 루틴을 삭제할 권한이 없습니다.");
+        }
+
+        routineRepository.deleteById(routineId);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -73,8 +73,8 @@ public class RoutineService {
                         .author(routine.getUser().getNickname())
                         .description(routine.getContent())
                         .liked(likedRoutineIdByUserEmail.contains(routine.getId()))
-                        .likeCounts(routine.getLikesCount())
-//                            .scrapCounts()
+                        .likeCounts(routineLikeRepository.countByRoutineId(routine.getId()))
+                        .scrapCounts(userRoutineCollectionRepository.countByRoutineId(routine.getId()))
                         .createdAt(routine.getCreatedAt())
                         .build())
                 .toList();
@@ -126,8 +126,8 @@ public class RoutineService {
                 .description(routine.getContent())
                 .liked(routineLikeRepository
                         .existsByUserEmailAndRoutineId(userEmail, routine.getId()))
-                .likeCounts(routine.getLikesCount())
-                .scrapCounts(0)
+                .likeCounts(routineLikeRepository.countByRoutineId(routine.getId()))
+                .scrapCounts(userRoutineCollectionRepository.countByRoutineId(routine.getId()))
                 .routine(RoutineDetailsResponseDto.RoutineDto.builder()
                         .id(routine.getId())
                         .days(dayDtos)

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -2,9 +2,11 @@ package com.ogjg.daitgym.routine.service;
 
 import com.ogjg.daitgym.comment.routine.exception.NotFoundRoutine;
 import com.ogjg.daitgym.domain.TimeTemplate;
+import com.ogjg.daitgym.domain.User;
 import com.ogjg.daitgym.domain.routine.Day;
 import com.ogjg.daitgym.domain.routine.ExerciseDetail;
 import com.ogjg.daitgym.domain.routine.Routine;
+import com.ogjg.daitgym.domain.routine.UserRoutineCollection;
 import com.ogjg.daitgym.exercise.exception.NotFoundExercise;
 import com.ogjg.daitgym.exercise.repository.ExerciseRepository;
 import com.ogjg.daitgym.follow.repository.FollowRepository;
@@ -17,6 +19,7 @@ import com.ogjg.daitgym.routine.exception.NoExerciseInRoutine;
 import com.ogjg.daitgym.routine.repository.DayRepository;
 import com.ogjg.daitgym.routine.repository.ExerciseDetailRepository;
 import com.ogjg.daitgym.routine.repository.RoutineRepository;
+import com.ogjg.daitgym.routine.repository.UserRoutineCollectionRepository;
 import com.ogjg.daitgym.user.exception.NotFoundUser;
 import com.ogjg.daitgym.user.exception.UnauthorizedUser;
 import com.ogjg.daitgym.user.repository.UserRepository;
@@ -40,11 +43,11 @@ import static com.ogjg.daitgym.routine.dto.RoutineDetailsResponseDto.*;
 public class RoutineService {
     private final ExerciseRepository exerciseRepository;
     private final UserRepository userRepository;
+    private final UserRoutineCollectionRepository userRoutineCollectionRepository;
 
     private final RoutineRepository routineRepository;
     private final FollowRepository followRepository;
     private final DayRepository dayRepository;
-    private final ExerciseDetailRepository exerciseDetailRepository;
     private final RoutineLikeRepository routineLikeRepository;
 
     @Transactional(readOnly = true)
@@ -223,5 +226,17 @@ public class RoutineService {
         }
 
         routineRepository.deleteById(routineId);
+    }
+
+    @Transactional
+    public void scrapRoutine(Long routineId, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(NotFoundUser::new);
+
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(NotFoundRoutine::new);
+
+        UserRoutineCollection userRoutineCollection = new UserRoutineCollection(user, routine);
+        userRoutineCollectionRepository.save(userRoutineCollection);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -18,7 +18,6 @@ import com.ogjg.daitgym.routine.dto.RoutineRequestDto;
 import com.ogjg.daitgym.routine.exception.NoExerciseInRoutine;
 import com.ogjg.daitgym.routine.exception.NotFoundScrapedUserRoutine;
 import com.ogjg.daitgym.routine.repository.DayRepository;
-import com.ogjg.daitgym.routine.repository.ExerciseDetailRepository;
 import com.ogjg.daitgym.routine.repository.RoutineRepository;
 import com.ogjg.daitgym.routine.repository.UserRoutineCollectionRepository;
 import com.ogjg.daitgym.user.exception.NotFoundUser;
@@ -252,5 +251,12 @@ public class RoutineService {
                 .orElseThrow(NotFoundScrapedUserRoutine::new);
 
         userRoutineCollectionRepository.delete(userRoutineCollection);
+    }
+
+    @Transactional(readOnly = true)
+    public RoutineListResponseDto getScrapedRoutines(String email, Pageable pageable) {
+        Slice<Routine> routinesByUserEmail = userRoutineCollectionRepository.findRoutinesByUserEmail(email, pageable);
+
+        return getRoutineListResponseDto(routinesByUserEmail, email);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -16,6 +16,7 @@ import com.ogjg.daitgym.routine.dto.RoutineDto;
 import com.ogjg.daitgym.routine.dto.RoutineListResponseDto;
 import com.ogjg.daitgym.routine.dto.RoutineRequestDto;
 import com.ogjg.daitgym.routine.exception.NoExerciseInRoutine;
+import com.ogjg.daitgym.routine.exception.NotFoundScrapedUserRoutine;
 import com.ogjg.daitgym.routine.repository.DayRepository;
 import com.ogjg.daitgym.routine.repository.ExerciseDetailRepository;
 import com.ogjg.daitgym.routine.repository.RoutineRepository;
@@ -238,5 +239,18 @@ public class RoutineService {
 
         UserRoutineCollection userRoutineCollection = new UserRoutineCollection(user, routine);
         userRoutineCollectionRepository.save(userRoutineCollection);
+    }
+
+    @Transactional
+    public void unscrapRoutine(Long routineId, String email) {
+
+        routineRepository.findById(routineId)
+                .orElseThrow(NotFoundRoutine::new);
+
+        UserRoutineCollection.PK pk = new UserRoutineCollection.PK(email, routineId);
+        UserRoutineCollection userRoutineCollection = userRoutineCollectionRepository.findById(pk)
+                .orElseThrow(NotFoundScrapedUserRoutine::new);
+
+        userRoutineCollectionRepository.delete(userRoutineCollection);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/user/exception/UnauthorizedUser.java
+++ b/src/main/java/com/ogjg/daitgym/user/exception/UnauthorizedUser.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.user.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class UnauthorizedUser extends CustomException {
+    public UnauthorizedUser() {
+        super(ErrorCode.UNAUTHORIZED_USER_ACCESS);
+    }
+
+    public UnauthorizedUser(String message) {
+        super(ErrorCode.UNAUTHORIZED_USER_ACCESS, message);
+    }
+
+    public UnauthorizedUser(ErrorData errorData) {
+        super(ErrorCode.UNAUTHORIZED_USER_ACCESS, errorData);
+    }
+}


### PR DESCRIPTION
## API
### [Feat : DIG-37 루틴 작성 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/2783841fb0436fd9836a211d00bbc39430cc9819) 
- 루틴 작성 기능 추가
- TimeTemplate를 사용해 restTime을 보관하도록 변경
### [Feat : DIG-39 루틴 삭제 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/7c239ca52297f13e09e7ca253a16164afa6f587b) 
- 루틴 삭제 기능 추가
- 삭제하려는 루틴의 사용자 본인이 아닌 경우 예외처리 적용
### [Feat : DIG-38 루틴 스크랩 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/6b93496a1219faed18c1d7cd8954d402fced9965) 
- 루틴 스크랩 기능 추가
- 유저와 루틴의 매핑 테이블을 생성하여 루틴을 보관할 수 있는 스크랩 기능을 구현
### [Feat : DIG-100 루틴 스크랩 취소 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/46e270a017ecf2cd698d0925889b9e9b15ddf765) 
- 루틴 스크랩 취소 추가
- 스크랩된 루틴을 찾을 수 없는 경우 예외 정의
### [Feat : DIG-36 루틴 스크랩 조회 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/5a17e005aa0b8df7ef7504d1e6a197df9e62b83a) 
- 루틴 스크랩 조회 기능 구현
- Slice를 활용한 무한 스크롤 데이터 반환
## 변경
### [Feat : DIG-101 루틴의 like, scrap 횟수 조회 로직 추가 및 변경](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/72094c4943ea0c9524ada94850293d95e2f64467) 
- 루틴 like, scrap 수 조회 로직 추가 및 변경
- DB에서 count하여 조회하는 방식으로 변경