### PR TITLE
Fix : RoutineRequestDto 내부 클래스 수정

### DIFF
--- a/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineRequestDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineRequestDto.java
@@ -12,13 +12,13 @@ public class RoutineRequestDto {
     private RoutineDto routine;
 
     @Getter
-    public class RoutineDto {
+    public static class RoutineDto {
         private Long id;
         private List<DayDto> days;
     }
 
     @Getter
-    public class DayDto {
+    public static class DayDto {
         private Long id;
         private int order;
         private long dayDate;
@@ -29,7 +29,7 @@ public class RoutineRequestDto {
     }
 
     @Getter
-    public class ExerciseDto {
+    public static class ExerciseDto {
         private Long id;
         private int order;
         private String name;
@@ -40,7 +40,7 @@ public class RoutineRequestDto {
     }
 
     @Getter
-    public class ExerciseSetDto {
+    public static class ExerciseSetDto {
         private Long id;
         private int order;
         private int weights;
@@ -49,14 +49,14 @@ public class RoutineRequestDto {
     }
 
     @Getter
-    public class RestTimeDto {
+    public static class RestTimeDto {
         private int hours;
         private int minutes;
         private int seconds;
     }
 
     @Getter
-    public class ExerciseTimeDto {
+    public static class ExerciseTimeDto {
         private int hours;
         private int minutes;
         private int seconds;


### PR DESCRIPTION
- DTO의 내부 클래스가 비 정적 클래스이기 때문에 Request 객체를 생성하지 못해 오류가 발생
- 내부 클래스를 정적 클래스로 변경