### PR TITLE
Chore : github workflow job 이름 변경

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- 배포의 작업을 하지만 build라는 이름으로 작업을 진행하고 있어 맞지 않다고 생각되어 변경