### PR TITLE
Feat : DIG-83 소셜 로그인 후 응답 값 수정, 회원 프로필 조회 시 조회 로직 추가, 회원 관련 기능 s3 이미지 저장 기능 추가

### DIFF
--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode implements ErrorType {
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "400", "중복되는 닉네임입니다."),
     UNAUTHORIZED_USER_ACCESS(HttpStatus.FORBIDDEN, "403", "접근 권한이 부족합니다."),
     NO_EXERCISE_IN_ROUTINE(HttpStatus.NOT_FOUND, "404", "루틴의 운동을 찾을 수 없습니다."),
-    ;
+    EMPTY_TRANIER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "트레이너 승인 신청에 아무것도 입력되지 않았습니다.");
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode implements ErrorType {
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "400", "중복되는 닉네임입니다."),
     UNAUTHORIZED_USER_ACCESS(HttpStatus.FORBIDDEN, "403", "접근 권한이 부족합니다."),
     NO_EXERCISE_IN_ROUTINE(HttpStatus.NOT_FOUND, "404", "루틴의 운동을 찾을 수 없습니다."),
-    EMPTY_TRANIER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "트레이너 승인 신청에 아무것도 입력되지 않았습니다.");
+    EMPTY_TRAINER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "잘못된 승인 신청입니다. 자격 혹은 수상내역 입력이 누락되었습니다.");
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/src/main/java/com/ogjg/daitgym/domain/AwardImage.java
+++ b/src/main/java/com/ogjg/daitgym/domain/AwardImage.java
@@ -30,4 +30,15 @@ public class AwardImage extends BaseEntity {
         this.award = award;
         this.url = url;
     }
+
+    public static AwardImage of(String url) {
+        return AwardImage.builder()
+                .url(url)
+                .build();
+    }
+
+    public AwardImage addAward(Award savedAward) {
+        this.award = savedAward;
+        return this;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/Certification.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Certification.java
@@ -48,4 +48,8 @@ public class Certification extends BaseEntity {
         this.issuingOrganization = issuingOrganization;
         this.acquisitionAt = acquisitionAt;
     }
+
+    public void addImage(CertificationImage certificationImage) {
+        this.certificationImages.add(certificationImage);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/CertificationImage.java
+++ b/src/main/java/com/ogjg/daitgym/domain/CertificationImage.java
@@ -30,4 +30,15 @@ public class CertificationImage extends BaseEntity {
         this.certification = certification;
         this.url = url;
     }
+
+    public static CertificationImage of(String url) {
+        return CertificationImage.builder()
+                .url(url)
+                .build();
+    }
+
+    public CertificationImage addAward(Certification savedCertification) {
+        this.certification = savedCertification;
+        return this;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/ExerciseSplit.java
+++ b/src/main/java/com/ogjg/daitgym/domain/ExerciseSplit.java
@@ -7,12 +7,12 @@ import java.util.Arrays;
 
 @Getter
 public enum ExerciseSplit {
-    ONE_DAY("1분할"),
+    ONE_DAY("무분할"),
     TWO_DAY("2분할"),
     THREE_DAY("3분할"),
     FOUR_DAY("4분할"),
     FIVE_DAY("5분할"),
-    OVER_SIX_DAY("6분할 이상"),
+    OVER_SIX_DAY("6분할+"),
     ;
 
     private String title;

--- a/src/main/java/com/ogjg/daitgym/domain/User.java
+++ b/src/main/java/com/ogjg/daitgym/domain/User.java
@@ -3,6 +3,7 @@ package com.ogjg.daitgym.domain;
 import com.ogjg.daitgym.domain.routine.Routine;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,6 +37,8 @@ public class User extends BaseEntity {
     private Routine activeRoutine;
 
     @Column(unique = true)
+    @Pattern(regexp = "^[A-Za-z0-9_]{3,11}$",
+            message = "사용 불가")
     private String nickname;
 
     private LocalDate birth;
@@ -70,8 +73,8 @@ public class User extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
-    public void editProfile(String awsImageUrl, String introduction, HealthClub healthClub, String split) {
-        this.imageUrl = awsImageUrl;
+    public void editProfile(String newImgUrl, String introduction, HealthClub healthClub, String split) {
+        this.imageUrl = newImgUrl;
         this.introduction = introduction;
         changeHealthClub(healthClub);
         this.preferredSplit = ExerciseSplit.titleFrom(split);

--- a/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
@@ -16,4 +16,5 @@ public interface ExerciseJournalRepository extends JpaRepository<ExerciseJournal
 
     int countByUserAndIsCompleted(User user, boolean completed);
 
+    int countByUserEmail(String email);
 }

--- a/src/main/java/com/ogjg/daitgym/user/controller/TokenController.java
+++ b/src/main/java/com/ogjg/daitgym/user/controller/TokenController.java
@@ -8,6 +8,8 @@ import com.ogjg.daitgym.config.security.jwt.dto.JwtUserClaimsDto;
 import com.ogjg.daitgym.config.security.jwt.util.JwtUtils;
 import com.ogjg.daitgym.domain.Role;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -77,11 +79,13 @@ public class TokenController {
         response.setCharacterEncoding(CHARSET_UTF_8);
     }
 
+    @Getter
+    @NoArgsConstructor
     static class TokenTestRequest {
         private String email;
         private String nickname;
-
         private String role;
+
         public TokenTestRequest(String email, String nickname, String role) {
             this.email = email;
             this.nickname = nickname;

--- a/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
+++ b/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
@@ -4,23 +4,20 @@ import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
 import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
 import com.ogjg.daitgym.user.dto.request.ApplyForApprovalRequest;
+import com.ogjg.daitgym.user.dto.request.EditNicknameRequest;
 import com.ogjg.daitgym.user.dto.request.EditUserProfileRequest;
 import com.ogjg.daitgym.user.dto.request.RegisterInbodyRequest;
+import com.ogjg.daitgym.user.dto.response.EditInitialNicknameResponse;
 import com.ogjg.daitgym.user.dto.response.GetInbodiesResponse;
 import com.ogjg.daitgym.user.dto.response.GetUserProfileGetResponse;
-import com.ogjg.daitgym.user.dto.request.EditNicknameRequest;
-import com.ogjg.daitgym.user.dto.response.EditInitialNicknameResponse;
 import com.ogjg.daitgym.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -99,7 +96,7 @@ public class UserController {
     @PutMapping("/{nickname}")
     public ApiResponse<Void> editUserProfile(
             @PathVariable("nickname") String nickname,
-            @RequestPart MultipartFile userProfileImg,
+            @RequestPart(required = false) MultipartFile userProfileImg,
             @RequestPart EditUserProfileRequest request,
             @AuthenticationPrincipal OAuth2JwtUserDetails userDetails
     ) {
@@ -114,8 +111,8 @@ public class UserController {
     @PostMapping("/career/submit")
     public ApiResponse<Void> applyForApproval(
             @RequestPart ApplyForApprovalRequest request,
-            @RequestPart List<MultipartFile> certificationImgs,
-            @RequestPart List<MultipartFile> awardImgs,
+            @RequestPart(required = false) List<MultipartFile> certificationImgs,
+            @RequestPart(required = false) List<MultipartFile> awardImgs,
             @AuthenticationPrincipal OAuth2JwtUserDetails userDetails
     ) {
         String loginEmail = userDetails.getEmail();

--- a/src/main/java/com/ogjg/daitgym/user/dto/request/ApplyForApprovalRequest.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/request/ApplyForApprovalRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
@@ -32,13 +33,13 @@ public class ApplyForApprovalRequest {
             this.acquisitionAt = acquisitionAt;
         }
 
-        public Certification toCertification(User user, List<String> imgUrls, Approval approval) {
+        public Certification toCertification(User user, Approval approval) {
             return Certification.builder()
                     .user(user)
                     .approval(approval)
                     .name(this.name)
                     .acquisitionAt(this.acquisitionAt)
-                    .certificationImages(toCertificationImgs(imgUrls))
+                    .certificationImages(new ArrayList<>())
                     .build();
         }
 
@@ -59,14 +60,14 @@ public class ApplyForApprovalRequest {
         private LocalDate awardAt;
         private String org;
 
-        public Award toAward(User user, List<String> imgUrls, Approval approval) {
+        public Award toAward(User user, Approval approval) {
             return Award.builder()
                     .user(user)
                     .approval(approval)
                     .awardName(this.name)
                     .awardAt(this.awardAt)
                     .hostOrganization(this.org)
-                    .awardImages(toAwardImages(imgUrls))
+                    .awardImages(new ArrayList<>())
                     .build();
         }
 

--- a/src/main/java/com/ogjg/daitgym/user/exception/EmptyTrainerApplyException.java
+++ b/src/main/java/com/ogjg/daitgym/user/exception/EmptyTrainerApplyException.java
@@ -7,14 +7,14 @@ import com.ogjg.daitgym.common.exception.ErrorData;
 public class EmptyTrainerApplyException extends CustomException {
 
     public EmptyTrainerApplyException() {
-        super(ErrorCode.EMPTY_TRANIER_APPLY_APPROVAL);
+        super(ErrorCode.EMPTY_TRAINER_APPLY_APPROVAL);
     }
 
     public EmptyTrainerApplyException(String message) {
-        super(ErrorCode.EMPTY_TRANIER_APPLY_APPROVAL, message);
+        super(ErrorCode.EMPTY_TRAINER_APPLY_APPROVAL, message);
     }
 
     public EmptyTrainerApplyException(ErrorData errorData) {
-        super(ErrorCode.EMPTY_TRANIER_APPLY_APPROVAL, errorData);
+        super(ErrorCode.EMPTY_TRAINER_APPLY_APPROVAL, errorData);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/user/exception/EmptyTrainerApplyException.java
+++ b/src/main/java/com/ogjg/daitgym/user/exception/EmptyTrainerApplyException.java
@@ -1,0 +1,20 @@
+package com.ogjg.daitgym.user.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class EmptyTrainerApplyException extends CustomException {
+
+    public EmptyTrainerApplyException() {
+        super(ErrorCode.EMPTY_TRANIER_APPLY_APPROVAL);
+    }
+
+    public EmptyTrainerApplyException(String message) {
+        super(ErrorCode.EMPTY_TRANIER_APPLY_APPROVAL, message);
+    }
+
+    public EmptyTrainerApplyException(ErrorData errorData) {
+        super(ErrorCode.EMPTY_TRANIER_APPLY_APPROVAL, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/user/service/AuthService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/AuthService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.ogjg.daitgym.config.security.jwt.dto.JwtUserClaimsDto;
+import com.ogjg.daitgym.domain.ExerciseSplit;
 import com.ogjg.daitgym.user.dto.LoginResponseDto;
 import com.ogjg.daitgym.domain.Role;
 import com.ogjg.daitgym.domain.User;
@@ -45,6 +46,9 @@ public class AuthService {
 
     @Value("${kakao.user-info-uri}")
     private String KAKAO_USER_INFO_URI;
+
+    @Value("${cloud.aws.default.profile-img}")
+    private String AWS_DEFAULT_PROFILE_IMG_URL;
 
     // 토큰으로 사용자 정보 가져오기 -> 처음 로그인인지 체크하고 로그인 응답 생성
     @Transactional
@@ -116,8 +120,9 @@ public class AuthService {
             return LoginResponseDto.builder()
                     .isAlreadyJoined(isAlreadyJoined)
                     .isDeleted(isDeleted)
+                    .preferredSplit(ExerciseSplit.ONE_DAY.getTitle())
                     .isAdmin(false)
-                    .userImg("defaultUrl")
+                    .userImg(AWS_DEFAULT_PROFILE_IMG_URL)
                     .nickname(tempNickname)
                     .build();
 
@@ -129,8 +134,9 @@ public class AuthService {
             return LoginResponseDto.builder()
                     .isAlreadyJoined(isAlreadyJoined)
                     .isDeleted(isDeleted)
+                    .preferredSplit(ExerciseSplit.ONE_DAY.getTitle())
                     .isAdmin(false)
-                    .userImg("defaultUrl")
+                    .userImg(AWS_DEFAULT_PROFILE_IMG_URL)
                     .nickname(tempNickname)
                     .build();
 
@@ -148,6 +154,7 @@ public class AuthService {
             return LoginResponseDto.builder()
                     .isAlreadyJoined(isAlreadyJoined)
                     .isDeleted(isDeleted)
+                    .preferredSplit(existUser.getPreferredSplit().getTitle())
                     .isAdmin(existUser.isAdmin())
                     .userImg(existUser.getImageUrl())
                     .nickname(existUser.getNickname())

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -65,7 +65,7 @@ public class UserService {
 
         return GetUserProfileGetResponse.builder()
                 .healthClubName(user.getHealthClub().getName())
-//                .journalCount(exerciseJournalRepository.countByUserEmail(user.getEmail()))
+                .journalCount(exerciseJournalRepository.countByUserEmail(user.getEmail()))
                 .followerCount(followRepository.countByFollowPKTargetEmail(user.getEmail()))
                 .followingCount(followRepository.countByFollowPKFollowerEmail(user.getEmail()))
                 .build();
@@ -241,10 +241,6 @@ public class UserService {
         String nickname = findUser.changeNickname(newNickname);
 
         return EditInitialNicknameResponse.of(nickname);
-    }
-
-    private boolean isUserNotFound(String loginEmail) {
-        return !userRepository.findByEmail(loginEmail).isPresent();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -5,25 +5,28 @@ import com.ogjg.daitgym.comment.feedExerciseJournal.exception.WrongApproach;
 import com.ogjg.daitgym.domain.*;
 import com.ogjg.daitgym.follow.repository.FollowRepository;
 import com.ogjg.daitgym.journal.repository.journal.ExerciseJournalRepository;
+import com.ogjg.daitgym.s3.repository.S3Repository;
 import com.ogjg.daitgym.user.dto.request.ApplyForApprovalRequest;
+import com.ogjg.daitgym.user.dto.request.EditNicknameRequest;
 import com.ogjg.daitgym.user.dto.request.EditUserProfileRequest;
 import com.ogjg.daitgym.user.dto.request.RegisterInbodyRequest;
+import com.ogjg.daitgym.user.dto.response.EditInitialNicknameResponse;
 import com.ogjg.daitgym.user.dto.response.GetInbodiesResponse;
 import com.ogjg.daitgym.user.dto.response.GetUserProfileGetResponse;
+import com.ogjg.daitgym.user.exception.AlreadyExistNickname;
+import com.ogjg.daitgym.user.exception.EmptyTrainerApplyException;
 import com.ogjg.daitgym.user.exception.NotFoundUser;
 import com.ogjg.daitgym.user.repository.HealthClubRepository;
 import com.ogjg.daitgym.user.repository.InbodyRepository;
-import com.ogjg.daitgym.domain.User;
-import com.ogjg.daitgym.user.dto.request.EditNicknameRequest;
-import com.ogjg.daitgym.user.dto.response.EditInitialNicknameResponse;
-import com.ogjg.daitgym.user.exception.AlreadyExistNickname;
 import com.ogjg.daitgym.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Collection;
 import java.util.List;
 
 @Service
@@ -48,7 +51,13 @@ public class UserService {
 
     private final InbodyRepository inbodyRepository;
 
+
     private final ExerciseJournalRepository exerciseJournalRepository;
+
+    private final S3Repository s3Repository;
+
+    @Value("${cloud.aws.default.profile-img}")
+    private String AWS_DEFAULT_PROFILE_IMG;
 
     @Transactional(readOnly = true)
     public GetUserProfileGetResponse getUserProfile(String loginEmail, String nickname) {
@@ -70,20 +79,34 @@ public class UserService {
             throw new WrongApproach("본인의 프로필만 수정할 수 있습니다.");
         }
 
-        // todo : s3에 이미지 저장
-//        MultipartFile multipartFile;
+        String newImgUrl;
+        String findImgUrl = user.getImageUrl();
 
-        String awsImageUrl = "image-aws.com";
+        // default 이미지 url 사용 시 삭제 방지
+        if (!findImgUrl.equals(AWS_DEFAULT_PROFILE_IMG)) {
+            s3Repository.deleteImageFromS3(findImgUrl);
+        }
+
+        if (isEmptyFile(multipartFile)) {
+            newImgUrl = findImgUrl;
+        } else {
+            // s3에 uuid로 랜덤 이름 생성해서 저장
+            newImgUrl = s3Repository.uploadImageToS3(multipartFile);
+        }
 
         //todo 헬스장 조회 수정, 수정 시 헬스장 식별자를 추가로 받아와야한다.
         HealthClub healthClub = findOrUpdateHealthClub(request.getGymName());
 
         user.editProfile(
-                awsImageUrl,
+                newImgUrl,
                 request.getIntroduction(),
                 healthClub,
                 request.getPreferredSplit()
         );
+    }
+
+    private static boolean isEmptyFile(MultipartFile multipartFile) {
+        return multipartFile == null || multipartFile.isEmpty();
     }
 
     private HealthClub findOrUpdateHealthClub(String name) {
@@ -101,19 +124,56 @@ public class UserService {
     @Transactional
     public void applyForApproval(String loginEmail, ApplyForApprovalRequest request, List<MultipartFile> awardImgs, List<MultipartFile> certificationImgs) {
         User user = findUserByEmail(loginEmail);
-        // todo : s3에 파일들 저장 및 url 반환
-        List<String> awardImgUrls = List.of("awsUrl4.com","awsUrl5.com","awsUrl6.com");
-        List<String> certificationImgUrls = List.of("awsUrl1.com","awsUrl2.com","awsUrl3.com");
 
+       /* //  수상 경력은 있으나 이미지가 누락됨
+        if (isEmptyCollection(request.getAwards()) && !isEmptyCollection(awardImgs)) {
+
+        }
+        // 자격증은 있으나 이미지가 누락됨
+        if (isEmptyCollection(request.getCertifications()) && !isEmptyCollection(awardImgs)) {
+
+        }*/
+
+        if (isEmptySubmit(request.getAwards(), awardImgs) && isEmptySubmit(request.getCertifications(), certificationImgs)) {
+            throw new EmptyTrainerApplyException();
+        }
+
+        // db 저장 로직
         Approval savedApproval = approvalRepository.save(Approval.builder().build());
 
-        List<Award> awards = awardRepository.saveAll(toAwards(user, request, awardImgUrls, savedApproval));
-        awards.stream()
-                .forEach(award -> awardImageRepository.saveAll(award.getAwardImages()));
+        // 수상 경력 관련해서 입력된 경우만 수행
+        if (!isEmptySubmit(request.getAwards(), awardImgs)) {
+            // s3 저장 로직
+            List<String> awardImgUrls = awardImgs.stream()
+                    .map((imgFile) -> s3Repository.uploadImageToS3(imgFile))
+                    .toList();
 
-        List<Certification> certifications = certificationRepository.saveAll(toCertifications(user, request, certificationImgUrls, savedApproval));
-        certifications.stream()
-                .forEach(certification -> certificationImageRepository.saveAll(certification.getCertificationImages()));
+            // db 저장 로직
+            List<Award> awards = awardRepository.saveAll(toAwards(user, request, awardImgUrls, savedApproval));
+            awards.stream()
+                    .forEach(award -> awardImageRepository.saveAll(award.getAwardImages()));
+        }
+
+        // 자격증 관련해서 입력된 경우만 수행
+        if (!isEmptySubmit(request.getCertifications(), certificationImgs)) {
+            // s3 저장 로직
+            List<String> certificationImgUrls = certificationImgs.stream()
+                    .map((imgFile) -> s3Repository.uploadImageToS3(imgFile))
+                    .toList();
+
+            // db 저장 로직
+            List<Certification> certifications = certificationRepository.saveAll(toCertifications(user, request, certificationImgUrls, savedApproval));
+            certifications.stream()
+                    .forEach(certification -> certificationImageRepository.saveAll(certification.getCertificationImages()));
+        }
+    }
+
+    private boolean isEmptySubmit(Collection<?> submitted, List<MultipartFile> awardImgs) {
+        return isEmptyCollection(submitted) && isEmptyCollection(awardImgs);
+    }
+
+    private boolean isEmptyCollection(Collection<?> collection) {
+        return collection == null || collection.isEmpty();
     }
 
     private List<Award> toAwards(User user, ApplyForApprovalRequest request, List<String> awardImgUrls, Approval approval) {


### PR DESCRIPTION
### [Feat : DIG-107 s3 이미지 저장 기능 추가](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/5fffbbe92594c35ecde87206f9b74b03ce71c665) 
- 자격증 심사 및 프로필 수정 시 이미지 s3  저장 기능 추가
  - 유저 프로필 수정 시 default 이미지 사용 여부 체크
  - 자격증 심사 및 프로필 수정 시 null 체크, 일부만 실행되도록 수정

### [Feat : DIG-83 유저 프로필 조회 시 운동일지 조회 기능 추가](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/95a7d680027922453b81e53ab5fdb9e258c36a0f)
- 충돌 방지로 누락시켰던 조회 로직 추가

### [Feat : DIG-83 소셜 로그인 후 응답 값 수정, User nickname 정규표현식 추가, ExerciseSplit 값 조정](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/d703da21b4d010ed62fc15a8ce55987dbd06411c)
- ExerciseSplit 값 조정
- nickname 정규표현식 추가
- 소셜로그인 후 응답 값에 기본 분할(무분할)  추가
- 소셜로그인 후 응답 값에 기본 imgUrl 추가

## 문제 -> 해결
### null 값 -> 빈 리스트 에러
- `트레이너 심사 신청 기능`에 이미지 배열 2개를 받아와서 s3 로직을 실행하는 부분이 있습니다. List<MultipartFile>을 required=false로 해두었을때, null 값이 들어오게 되는 것을 방지하기 위해 null 체크를 해두었습니다. 
- 해당 부분을 빈 리스트로 바꾼다면, 별다른 null체크 없이도 save로직이 제대로 동작할 거라 예측됩니다.
- 해당 부분을 util 클래스를 만들어 리팩터링할 예정입니다.
+ 그래서 빈 리스트로 save 하면 s3로직에서 빈 이미지들이 저장됩니다.
+ List<MultipartFile>은 null 값이 들어와도 1개 길이의 리스트가 들어옵니다.

### 타입 에러
- \@RequestParts로 컨트롤러에서 body에 json과 MultipartFile을 같이 받으려면 클라이언트에서 각각 타입을 명시해줘야 하는데 전송을 위한 로직이 복잡해집니다.
- 보통 서버측에서 수동 변환해서 사용한다고 합니다.

### 해결
- List<MultipartFile> 및 null 체크 로직 추가
- 수동변환해서 타입에러 해결

### 추가 버그
- url이 encoding되어있어서 제목이 조금 길면 너무 길어져서 db에 들어가지 않는다.