### PR TITLE
fix : DIG-112 루틴 API 버그 수정(Entity, DTO, 로직)

### DIFF
--- a/src/main/java/com/ogjg/daitgym/domain/routine/Day.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/Day.java
@@ -31,9 +31,8 @@ public class Day {
     private int dayNumber;
 
     @Builder
-    public Day(Routine routine, List<ExerciseDetail> exerciseDetails, int dayNumber) {
+    public Day(Routine routine, int dayNumber) {
         this.routine = routine;
-        this.exerciseDetails = exerciseDetails;
         this.dayNumber = dayNumber;
     }
 

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDetailsResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDetailsResponseDto.java
@@ -1,10 +1,12 @@
 package com.ogjg.daitgym.routine.dto;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Getter
 public class RoutineDetailsResponseDto {
 
     private String writer;
@@ -30,6 +32,7 @@ public class RoutineDetailsResponseDto {
         this.routine = routine;
     }
 
+    @Getter
     public static class RoutineDto {
         private Long id;
         private List<DayDto> days;
@@ -41,6 +44,7 @@ public class RoutineDetailsResponseDto {
         }
     }
 
+    @Getter
     public static class DayDto {
         private Long id;
         private int order;
@@ -56,6 +60,7 @@ public class RoutineDetailsResponseDto {
         }
     }
 
+    @Getter
     public static class ExerciseDto {
         private Long id;
         private int order;
@@ -75,6 +80,7 @@ public class RoutineDetailsResponseDto {
         }
     }
 
+    @Getter
     public static class RestTimeDto {
         private int hours;
         private int minutes;
@@ -88,6 +94,7 @@ public class RoutineDetailsResponseDto {
         }
     }
 
+    @Getter
     public static class ExerciseSets {
         private Long id;
         private int order;

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
@@ -1,9 +1,11 @@
 package com.ogjg.daitgym.routine.dto;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 public class RoutineDto {
 
     private Long id;

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineListResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineListResponseDto.java
@@ -1,9 +1,11 @@
 package com.ogjg.daitgym.routine.dto;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 public class RoutineListResponseDto {
     private List<RoutineDto> routines;
     private int currentPage;

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -60,9 +60,6 @@ public class RoutineService {
     }
 
     private RoutineListResponseDto getRoutineListResponseDto(Slice<Routine> routines, String email) {
-        if (!routines.hasNext()) {
-            throw new NotFoundRoutine("더 이상 루틴이 존재하지 않습니다.");
-        }
 
         Set<Long> likedRoutineIdByUserEmail = routineLikeRepository.findLikedRoutineIdByUserEmail(email);
 


### PR DESCRIPTION
- [x] Day Entity의 생성자에서 exerciseDetails를 받아 초기화하기 때문에 NPE 발생.
    - exerciseDetails의 값이 null로 들어오기 때문에 발생하는 것으로 추정되어 초기 JPA를 통한 초기화 값을 사용하도록 생성자에서 제거
- [x] 루틴의 마지막 페이지에서 다음 페이지가 없다면 예외가 발생하도록 정의했지만, 마지막 페이지의 루틴을 반환하지 못해 에러가 발생.
    - 해당 로직은 굳이 필요하지 않다고 판단하여 제거
- [x] DTO에 getter가 존재하지 않아 직렬화 할 수 없어 에러가 발생. 
    - @Getter를 추가하여 해결. 
    - 스프링에서 사용하는 Jackson은 getter 메서드를 사용해 JSON으로 변환한다.