### PR TITLE
Fix : DIG-111 프로필 불러오기 응답 값에 프로필 관련 정보 추가

### DIFF
--- a/src/main/java/com/ogjg/daitgym/user/dto/response/GetInbodiesResponse.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/response/GetInbodiesResponse.java
@@ -30,7 +30,7 @@ public class GetInbodiesResponse {
         private LocalDate measureAt;
         private int inbodyScore;
         private double skeletalMuscleMass;
-        private double bodyFatRatio ;
+        private double bodyFatRatio;
         private double weight;
         private int basalMetabolicRate;
 
@@ -78,7 +78,7 @@ public class GetInbodiesResponse {
             }
 
             private static double getRoundedAverage(double total, double count) {
-                return Math.round(total / count * 100.0) / 10000.0;
+                return Math.round(total / count * 100.0) / 100.0;
             }
         }
     }

--- a/src/main/java/com/ogjg/daitgym/user/dto/response/GetUserProfileGetResponse.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/response/GetUserProfileGetResponse.java
@@ -10,25 +10,24 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class GetUserProfileGetResponse {
 
+    private String nickname;
+    private String preferredSplit;
+    private String userProfileImgUrl;
+    private String introduction;
     private String healthClubName;
     private int journalCount;
     private int followerCount;
     private int followingCount;
 
     @Builder
-    public GetUserProfileGetResponse(String healthClubName, int journalCount, int followerCount, int followingCount) {
+    public GetUserProfileGetResponse(String nickname, String preferredSplit, String userProfileImgUrl, String introduction, String healthClubName, int journalCount, int followerCount, int followingCount) {
+        this.nickname = nickname;
+        this.preferredSplit = preferredSplit;
+        this.userProfileImgUrl = userProfileImgUrl;
+        this.introduction = introduction;
         this.healthClubName = healthClubName;
         this.journalCount = journalCount;
         this.followerCount = followerCount;
         this.followingCount = followingCount;
-    }
-
-    public static GetUserProfileGetResponse of(int journalCount, int followerCount, int followingCount, String healthClubName) {
-        return GetUserProfileGetResponse.builder()
-                .healthClubName(healthClubName)
-                .journalCount(journalCount)
-                .followerCount(followerCount)
-                .followingCount(followingCount)
-                .build();
     }
 }

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -66,6 +66,10 @@ public class UserService {
         User user = findUserByNickname(nickname);
 
         return GetUserProfileGetResponse.builder()
+                .nickname(user.getNickname())
+                .preferredSplit(user.getPreferredSplit().getTitle())
+                .userProfileImgUrl(user.getImageUrl())
+                .introduction(user.getIntroduction())
                 .healthClubName(user.getHealthClub().getName())
                 .journalCount(exerciseJournalRepository.countByUserEmail(user.getEmail()))
                 .followerCount(followRepository.countByFollowPKTargetEmail(user.getEmail()))


### PR DESCRIPTION
- 프론트에서 편의를 위해 상태유지하는 값들이 있습니다.
- 상대 프로필을 보기 위해 상태유지하는 값들을 직접 응답 값으로 내려달라는 요청을 받았습니다.
- 추가로 수정했던 평균 계산 로직에 오류가 있어 재수정했습니다.