### PR TITLE
fix : DIG-112 루틴 상세 조회 로직 변경

### DIFF
--- a/src/main/java/com/ogjg/daitgym/domain/routine/ExerciseDetail.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/ExerciseDetail.java
@@ -37,16 +37,19 @@ public class ExerciseDetail extends BaseEntity {
 
     private int exerciseOrder;
 
+    private int setOrder;
+
     private TimeTemplate restTime;
 
     @Builder
-    public ExerciseDetail(Day day, Exercise exercise, int setCount, int repetitionCount, int weight, int exerciseOrder, TimeTemplate restTime) {
+    public ExerciseDetail(Day day, Exercise exercise, int setCount, int repetitionCount, int weight, int exerciseOrder, int setOrder, TimeTemplate restTime) {
         this.day = day;
         this.exercise = exercise;
         this.setCount = setCount;
         this.repetitionCount = repetitionCount;
         this.weight = weight;
         this.exerciseOrder = exerciseOrder;
+        this.setOrder = setOrder;
         this.restTime = restTime;
     }
 

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDetailsResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDetailsResponseDto.java
@@ -1,5 +1,6 @@
 package com.ogjg.daitgym.routine.dto;
 
+import com.ogjg.daitgym.domain.TimeTemplate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -100,14 +101,16 @@ public class RoutineDetailsResponseDto {
         private int order;
         private int weights;
         private int counts;
+        private TimeTemplate restTime;
         private boolean completed;
 
         @Builder
-        public ExerciseSets(Long id, int order, int weights, int counts, boolean completed) {
+        public ExerciseSets(Long id, int order, int weights, int counts, TimeTemplate restTime, boolean completed) {
             this.id = id;
             this.order = order;
             this.weights = weights;
             this.counts = counts;
+            this.restTime = restTime;
             this.completed = completed;
         }
     }


### PR DESCRIPTION
- [x] 루틴의 운동 내역에 대한 DTO 생성 로직이 그룹화 되지 않아 운동 레벨에 생성이 되는 문제가 발생 
    - 운동에 맞게 그룹화하여 운동에 대한 내역을 DTO를 생성하여 Exercise에 포함하도록 변경
- [x] DTO에서도 TimeTemplate 객체를 사용하도록 변경