### PR TITLE
루틴 추가 구현 및 버그 수정

### DIFF
--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode implements ErrorType {
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "400", "중복되는 닉네임입니다."),
     UNAUTHORIZED_USER_ACCESS(HttpStatus.FORBIDDEN, "403", "접근 권한이 부족합니다."),
     NO_EXERCISE_IN_ROUTINE(HttpStatus.NOT_FOUND, "404", "루틴의 운동을 찾을 수 없습니다."),
-    EMPTY_TRAINER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "잘못된 승인 신청입니다. 자격 혹은 수상내역 입력이 누락되었습니다.");
+    EMPTY_TRAINER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "잘못된 승인 신청입니다. 자격 혹은 수상내역 입력이 누락되었습니다."),
+    ALREADY_SCRAPED_ROUTINE(HttpStatus.BAD_REQUEST, "400", "이미 스크랩한 루틴입니다.");
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
+++ b/src/main/java/com/ogjg/daitgym/domain/routine/Routine.java
@@ -47,10 +47,13 @@ public class Routine extends BaseEntity {
     @Enumerated(STRING)
     private UnitType unitType;
 
+    @OneToMany(mappedBy = "routine", fetch = LAZY, cascade = ALL, orphanRemoval = true)
+    private List<Day> days = new ArrayList<>();
+
     @OneToMany(mappedBy = "routine", fetch = LAZY)
     private Set<RoutineLike> routineLikes = new HashSet<>();
 
-    @OneToMany(mappedBy = "routine", cascade = ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "routine", fetch = LAZY, cascade = ALL, orphanRemoval = true)
     private List<UserRoutineCollection> userRoutineCollections = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/ogjg/daitgym/like/routine/repository/RoutineLikeRepository.java
+++ b/src/main/java/com/ogjg/daitgym/like/routine/repository/RoutineLikeRepository.java
@@ -15,6 +15,9 @@ public interface RoutineLikeRepository extends JpaRepository<RoutineLike, Long> 
     @Query("SELECT rl.routine.id FROM RoutineLike rl WHERE rl.user.email = :email")
     Set<Long> findLikedRoutineIdByUserEmail(String email);
 
+    @Query("SELECT rl.routine.id FROM RoutineLike rl WHERE rl.user.nickname = :nickname")
+    Set<Long> findLikedRoutineIdByUserNickname(String nickname);
+
     @Query("SELECT COUNT(rl) FROM RoutineLike rl WHERE rl.routine.id = :routineId")
     long countByRoutineId(@Param("routineId") Long routineId);
 

--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -34,12 +34,12 @@ public class RoutineController {
         return new ApiResponse<>(ErrorCode.SUCCESS, routines);
     }
 
-    @GetMapping("/{userEmail}")
+    @GetMapping("/{nickname}")
     public ApiResponse<RoutineListResponseDto> getUserRoutines(
-            @PathVariable("userEmail") String userEmail,
+            @PathVariable("nickname") String nickname,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(value = "division", required = false) Integer division) {
-        RoutineListResponseDto userRoutines = routineService.getUserRoutines(userEmail, division, pageable);
+        RoutineListResponseDto userRoutines = routineService.getUserRoutines(nickname, division, pageable);
 
         return new ApiResponse<>(ErrorCode.SUCCESS, userRoutines);
     }

--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -84,7 +84,7 @@ public class RoutineController {
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
-    @GetMapping("/scrap/{routineId}")
+    @PostMapping("/scrap/{routineId}")
     public ApiResponse<Void> scrapRoutine(
             @PathVariable("routineId") Long routineId,
             @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
@@ -19,7 +19,6 @@ public class RoutineDto {
     private LocalDateTime createdAt;
 
     @Builder
-
     public RoutineDto(Long id, String title, String author, String authorImg, String description, boolean liked, long likeCounts, long scrapCounts, LocalDateTime createdAt) {
         this.id = id;
         this.title = title;

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
@@ -11,6 +11,7 @@ public class RoutineDto {
     private Long id;
     private String title;
     private String author;
+    private String authorImg;
     private String description;
     private boolean liked;
     private long likeCounts;
@@ -18,10 +19,12 @@ public class RoutineDto {
     private LocalDateTime createdAt;
 
     @Builder
-    public RoutineDto(Long id, String title, String author, String description, boolean liked, long likeCounts, long scrapCounts, LocalDateTime createdAt) {
+
+    public RoutineDto(Long id, String title, String author, String authorImg, String description, boolean liked, long likeCounts, long scrapCounts, LocalDateTime createdAt) {
         this.id = id;
         this.title = title;
         this.author = author;
+        this.authorImg = authorImg;
         this.description = description;
         this.liked = liked;
         this.likeCounts = likeCounts;

--- a/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
+++ b/src/main/java/com/ogjg/daitgym/routine/dto/RoutineDto.java
@@ -15,11 +15,12 @@ public class RoutineDto {
     private String description;
     private boolean liked;
     private long likeCounts;
+    private boolean scraped;
     private long scrapCounts;
     private LocalDateTime createdAt;
 
     @Builder
-    public RoutineDto(Long id, String title, String author, String authorImg, String description, boolean liked, long likeCounts, long scrapCounts, LocalDateTime createdAt) {
+    public RoutineDto(Long id, String title, String author, String authorImg, String description, boolean liked, long likeCounts, boolean scraped, long scrapCounts, LocalDateTime createdAt) {
         this.id = id;
         this.title = title;
         this.author = author;
@@ -27,6 +28,7 @@ public class RoutineDto {
         this.description = description;
         this.liked = liked;
         this.likeCounts = likeCounts;
+        this.scraped = scraped;
         this.scrapCounts = scrapCounts;
         this.createdAt = createdAt;
     }

--- a/src/main/java/com/ogjg/daitgym/routine/exception/AlreadyScrapedRoutine.java
+++ b/src/main/java/com/ogjg/daitgym/routine/exception/AlreadyScrapedRoutine.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.routine.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class AlreadyScrapedRoutine extends CustomException {
+    public AlreadyScrapedRoutine() {
+        super(ErrorCode.ALREADY_SCRAPED_ROUTINE);
+    }
+
+    public AlreadyScrapedRoutine(String message) {
+        super(ErrorCode.ALREADY_SCRAPED_ROUTINE, message);
+    }
+
+    public AlreadyScrapedRoutine(ErrorData errorData) {
+        super(ErrorCode.ALREADY_SCRAPED_ROUTINE, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/RoutineRepository.java
@@ -15,8 +15,8 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
     @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division)")
     Optional<Slice<Routine>> findAllByDivision(@Param("division") Integer division, Pageable pageable);
 
-    @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division) AND r.user.email = :email")
-    Optional<Slice<Routine>> findByDivisionAndUserEmail(@Param("division") Integer division, @Param("email") String email, Pageable pageable);
+    @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division) AND r.user.nickname = :nickname")
+    Optional<Slice<Routine>> findByDivisionAndUserNickname(@Param("division") Integer division, @Param("nickname") String nickname, Pageable pageable);
 
     @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division) AND r.user.email IN :followerEmails")
     Optional<Slice<Routine>> findByDivisionAndUserEmailIn(@Param("division") Integer division, @Param("followerEmails") List<String> followerEmails, Pageable pageable);

--- a/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Set;
+
 import static com.ogjg.daitgym.domain.routine.UserRoutineCollection.*;
 
 public interface UserRoutineCollectionRepository extends JpaRepository<UserRoutineCollection, PK> {
@@ -17,4 +19,10 @@ public interface UserRoutineCollectionRepository extends JpaRepository<UserRouti
 
     @Query("SELECT COUNT(urc) FROM UserRoutineCollection urc WHERE urc.pk.routineId = :routineId")
     long countByRoutineId(@Param("routineId") Long routineId);
+
+    @Query("SELECT urc.routine.id FROM UserRoutineCollection urc WHERE urc.user.email = :email")
+    Set<Long> findScrapedRoutineIdByUserEmail(String email);
+
+    @Query("SELECT urc.routine.id FROM UserRoutineCollection urc WHERE urc.user.nickname = :nickname")
+    Set<Long> findScrapedRoutineIdByUserNickname(String nickname);
 }

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -69,6 +69,7 @@ public class RoutineService {
                         .id(routine.getId())
                         .title(routine.getTitle())
                         .author(routine.getUser().getNickname())
+                        .authorImg(routine.getUser().getImageUrl())
                         .description(routine.getContent())
                         .liked(likedRoutineIdByUserEmail.contains(routine.getId()))
                         .likeCounts(routineLikeRepository.countByRoutineId(routine.getId()))

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -63,6 +63,7 @@ public class RoutineService {
     private RoutineListResponseDto getRoutineListResponseDto(Slice<Routine> routines, String identifier) {
 
         Set<Long> likedRoutineIds = getLikedRoutineIds(identifier);
+        Set<Long> scrapedRoutineIds = getScrapedRoutineIds(identifier);
 
         List<RoutineDto> routineDtos = routines.stream()
                 .map(routine -> RoutineDto.builder()
@@ -73,6 +74,7 @@ public class RoutineService {
                         .description(routine.getContent())
                         .liked(likedRoutineIds.contains(routine.getId()))
                         .likeCounts(routineLikeRepository.countByRoutineId(routine.getId()))
+                        .scraped(scrapedRoutineIds.contains(routine.getId()))
                         .scrapCounts(userRoutineCollectionRepository.countByRoutineId(routine.getId()))
                         .createdAt(routine.getCreatedAt())
                         .build())
@@ -85,11 +87,20 @@ public class RoutineService {
                 .build();
     }
 
+
     private Set<Long> getLikedRoutineIds(String identifier) {
         if (isEmail(identifier)) {
             return routineLikeRepository.findLikedRoutineIdByUserEmail(identifier);
         } else {
             return routineLikeRepository.findLikedRoutineIdByUserNickname(identifier);
+        }
+    }
+
+    private Set<Long> getScrapedRoutineIds(String identifier) {
+        if (isEmail(identifier)) {
+            return userRoutineCollectionRepository.findScrapedRoutineIdByUserEmail(identifier);
+        } else {
+            return userRoutineCollectionRepository.findScrapedRoutineIdByUserNickname(identifier);
         }
     }
 

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -15,6 +15,7 @@ import com.ogjg.daitgym.routine.dto.RoutineDetailsResponseDto;
 import com.ogjg.daitgym.routine.dto.RoutineDto;
 import com.ogjg.daitgym.routine.dto.RoutineListResponseDto;
 import com.ogjg.daitgym.routine.dto.RoutineRequestDto;
+import com.ogjg.daitgym.routine.exception.AlreadyScrapedRoutine;
 import com.ogjg.daitgym.routine.exception.NoExerciseInRoutine;
 import com.ogjg.daitgym.routine.exception.NotFoundScrapedUserRoutine;
 import com.ogjg.daitgym.routine.repository.DayRepository;
@@ -272,6 +273,10 @@ public class RoutineService {
                 .orElseThrow(NotFoundRoutine::new);
 
         UserRoutineCollection userRoutineCollection = new UserRoutineCollection(user, routine);
+        if (userRoutineCollectionRepository.findById(userRoutineCollection.getPk()).isPresent()) {
+            throw new AlreadyScrapedRoutine();
+        }
+
         userRoutineCollectionRepository.save(userRoutineCollection);
     }
 


### PR DESCRIPTION
### [fix : DIG-112 루틴 조회 시 누락된 유저 이미지 추가](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/79134955d56c1c3c7c9ef41a18d9eb937c837248) 
- 루틴 목록 조회 시, 유저의 이미지 데이터를 반환하도록 수정
### [Feat : DIG-115 유저의 루틴 목록 조회를 닉네임으로 조회 하도록 변경](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/ec62aeb3e90405a65062f8d093e8a1dd763a6797) 
- RoutineRepository 쿼리를 닉네임으로 조회하도록 변경
- getRoutineListResponseDto() 메서드에서 유저의 ID가 이메일인지 식별할 수 있도록 isEmail() 메서드 정의
    - email, nickname에 따라 RoutineLikeRepository의 쿼리가 변경
- RoutineLikeRepository에 nickname 조회 쿼리 메서드 추가 정의
### [Fix : DIG-117 루틴 스크랩 API 메서드 변경](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/d200d665d8ad55641804816033dfd9ca00bfff23) 
- Get 메서드에서 Post 메서드로 변경
### [Fix : DIG-117 조회 시 스크랩 여부 추가](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/5ec2250e15c23ef0eafde99f37451a73b2d51051) 

- 조회하는 루틴이 스크랩된 루틴인 지 확인
### [Fix : DIG-116 루틴 삭제가 되지 않는 버그 수정](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/dd935e8cb28e135e8406dec975e65a99513ee476) 

- 연관 관계 설정으로 Day와 묶여 있기 때문에 삭제가 되지 않아 예외가 발생
- cascade 옵션을 설정하여 삭제 시 연관된 데이터가 삭제되도록 수정