### PR TITLE
Fix : 루틴 스크랩 API URL 변경

### DIFF
--- a/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
+++ b/src/main/java/com/ogjg/daitgym/routine/controller/RoutineController.java
@@ -87,7 +87,7 @@ public class RoutineController {
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
-    @PostMapping("/scrap/{routineId}")
+    @PostMapping("/{routineId}/scrap")
     public ApiResponse<Map<String, Long>> scrapRoutine(
             @PathVariable("routineId") Long routineId,
             @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {
@@ -96,7 +96,7 @@ public class RoutineController {
         return new ApiResponse<>(ErrorCode.SUCCESS, Map.of("scrapCnt", scrappedCounts));
     }
 
-    @DeleteMapping("/scrap/{routineId}")
+    @DeleteMapping("/{routineId}/scrap")
     public ApiResponse<Map<String, Long>> unscrapRoutine(
             @PathVariable("routineId") Long routineId,
             @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {


### PR DESCRIPTION
- 통일성을 위해 앤드포인트를 `/scrap/{routineId}` 에서 `/{routineId}/scrap`로 변경