### PR TITLE
Fix / Refactor 운동일지 관련 예외 버그 수정 

### DIFF
--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode implements ErrorType {
     SUCCESS(HttpStatus.OK, "200", "OK"),
     ALREADY_FOLLOW_USER(HttpStatus.BAD_REQUEST, "400", "이미 팔로우한 유저입니다"),
     ALREADY_EXIST_FEED_COLLECTION(HttpStatus.BAD_REQUEST, "400", "이미 스크랩한 피드 운동일지 게시물입니다"),
+    ALREADY_SHARED_JOURNAL(HttpStatus.BAD_REQUEST, "400", "이미 공유된 운동일지입니다"),
+    ALREADY_EXIST_EXERCISE_JOURNAL(HttpStatus.BAD_REQUEST, "400", "이미 존재하는 운동일지입니다"),
     RANGE_OVER_IMAGES(HttpStatus.BAD_REQUEST,"400","이미지의 개수는 10개를 초과할 수 없습니다"),
     NOT_FOUND_FOLLOW(HttpStatus.NOT_FOUND, "404", "팔로우를 먼저 해주세요"),
     NOT_FOUND_EXERCISE(HttpStatus.NOT_FOUND, "404", "운동을 찾을 수 없습니다"),

--- a/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournalImage.java
+++ b/src/main/java/com/ogjg/daitgym/domain/feed/FeedExerciseJournalImage.java
@@ -22,6 +22,7 @@ public class FeedExerciseJournalImage {
     @JoinColumn(name = "feed_journal_id")
     private FeedExerciseJournal feedExerciseJournal;
 
+    @Lob
     private String imageUrl;
 
     public FeedExerciseJournalImage(FeedExerciseJournal feedExerciseJournal, String imageUrl) {

--- a/src/main/java/com/ogjg/daitgym/feed/exception/AlreadyExistFeedJournal.java
+++ b/src/main/java/com/ogjg/daitgym/feed/exception/AlreadyExistFeedJournal.java
@@ -1,0 +1,20 @@
+package com.ogjg.daitgym.feed.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class AlreadyExistFeedJournal extends CustomException {
+
+    public AlreadyExistFeedJournal() {
+        super(ErrorCode.ALREADY_SHARED_JOURNAL);
+    }
+
+    public AlreadyExistFeedJournal(String message) {
+        super(ErrorCode.ALREADY_SHARED_JOURNAL, message);
+    }
+
+    public AlreadyExistFeedJournal(ErrorData errorData) {
+        super(ErrorCode.ALREADY_SHARED_JOURNAL, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/feed/service/FeedJournalHelperService.java
+++ b/src/main/java/com/ogjg/daitgym/feed/service/FeedJournalHelperService.java
@@ -4,6 +4,7 @@ package com.ogjg.daitgym.feed.service;
 import com.ogjg.daitgym.comment.feedExerciseJournal.exception.NotFoundFeedJournal;
 import com.ogjg.daitgym.domain.User;
 import com.ogjg.daitgym.domain.feed.FeedExerciseJournal;
+import com.ogjg.daitgym.domain.journal.ExerciseJournal;
 import com.ogjg.daitgym.feed.repository.FeedExerciseJournalRepository;
 import com.ogjg.daitgym.user.exception.NotFoundUser;
 import com.ogjg.daitgym.user.repository.UserRepository;
@@ -23,6 +24,13 @@ public class FeedJournalHelperService {
     public FeedExerciseJournal findFeedJournalById(Long feedJournalId) {
         return feedExerciseJournalRepository.findById(feedJournalId)
                 .orElseThrow(NotFoundFeedJournal::new);
+    }
+
+    /**
+     * 운동일지로 피드운동일지가 존재하는지 확인하기
+     */
+    public boolean checkExistFeedExerciseJournalByExerciseJournal(ExerciseJournal exerciseJournal){
+        return feedExerciseJournalRepository.findByExerciseJournal(exerciseJournal).isPresent();
     }
 
     public User findUserByNickname(String nickname) {

--- a/src/main/java/com/ogjg/daitgym/journal/exception/AlreadyExistExerciseJournal.java
+++ b/src/main/java/com/ogjg/daitgym/journal/exception/AlreadyExistExerciseJournal.java
@@ -1,0 +1,20 @@
+package com.ogjg.daitgym.journal.exception;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class AlreadyExistExerciseJournal extends CustomException {
+
+    public AlreadyExistExerciseJournal() {
+        super(ErrorCode.ALREADY_EXIST_EXERCISE_JOURNAL);
+    }
+
+    public AlreadyExistExerciseJournal(String message) {
+        super(ErrorCode.ALREADY_EXIST_EXERCISE_JOURNAL, message);
+    }
+
+    public AlreadyExistExerciseJournal(ErrorData errorData) {
+        super(ErrorCode.ALREADY_EXIST_EXERCISE_JOURNAL, errorData);
+    }
+}


### PR DESCRIPTION
### [Refactor : 피드 이미지 imageUrl 길이 확장](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/ec4cbeb93b235c8aa78d02ad1b5c57ca95ac2f9d) 

- [ ] 피드 이미지 imageUrl 길이 확장

---

[Fix : 운동일지 예외에 대한 버그 수정](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/64a1eef1e1e30878ef623f42875fa5e964f6a377) 

- [ ] 일지 삭제시 피드가 존재하지않으면 예외가 발생하는 버그 수정
- [ ] 일지 공유시 이미 공유된 상태라면 공유할 수 없다는 예외를 발생
- [ ] 운동일지 생성시 해당 날짜에 일지가 존재한다면 예외 발생