### PR TITLE
Refactor, Fix : S3Service 생성하여 유저관련 s3 로직 분리, 프로필 편집 기능 nickname 중복 버그 수정

### DIFF
--- a/src/main/java/com/ogjg/daitgym/domain/Award.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Award.java
@@ -55,4 +55,11 @@ public class Award extends BaseEntity {
         this.awardName = awardName;
         this.awardAt = awardAt;
     }
+
+    public List<AwardImage> saveImages(List<String> awardImgUrls) {
+        return this.awardImages = awardImgUrls.stream()
+                .map(AwardImage::of)
+                .map((awardImage -> awardImage.addAward(this)))
+                .toList();
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/Certification.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Certification.java
@@ -49,7 +49,10 @@ public class Certification extends BaseEntity {
         this.acquisitionAt = acquisitionAt;
     }
 
-    public void addImage(CertificationImage certificationImage) {
-        this.certificationImages.add(certificationImage);
+    public List<CertificationImage> saveImages(List<String> certificationImgUrls) {
+        return this.certificationImages = certificationImgUrls.stream()
+                .map(CertificationImage::of)
+                .map((certificationImage -> certificationImage.addCertification(this)))
+                .toList();
     }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/CertificationImage.java
+++ b/src/main/java/com/ogjg/daitgym/domain/CertificationImage.java
@@ -37,7 +37,7 @@ public class CertificationImage extends BaseEntity {
                 .build();
     }
 
-    public CertificationImage addAward(Certification savedCertification) {
+    public CertificationImage addCertification(Certification savedCertification) {
         this.certification = savedCertification;
         return this;
     }

--- a/src/main/java/com/ogjg/daitgym/domain/User.java
+++ b/src/main/java/com/ogjg/daitgym/domain/User.java
@@ -28,7 +28,8 @@ public class User extends BaseEntity {
     private String email;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "health_club_id")
+    @JoinColumn(name = "health_" +
+            "club_id")
     private HealthClub healthClub;
 
     @OneToOne(fetch = LAZY)
@@ -72,15 +73,14 @@ public class User extends BaseEntity {
 
     public void editProfile(String newImgUrl, String nickname, String introduction, HealthClub healthClub, String split) {
         this.imageUrl = newImgUrl;
-        this.nickname = nickname;
+        changeNickname(nickname);
         this.introduction = introduction;
         changeHealthClub(healthClub);
         this.preferredSplit = ExerciseSplit.titleFrom(split);
     }
 
     public String changeNickname(String newNickname) {
-        this.nickname = newNickname;
-        return this.nickname;
+        return this.nickname = newNickname;
     }
 
     public void withdraw() {
@@ -96,9 +96,5 @@ public class User extends BaseEntity {
             newHealthClub.getUsers().add(this);
         }
         this.healthClub = newHealthClub;
-    }
-
-    public boolean isAdmin() {
-        return this.role == Role.ADMIN;
     }
 }

--- a/src/main/java/com/ogjg/daitgym/s3/service/S3UserService.java
+++ b/src/main/java/com/ogjg/daitgym/s3/service/S3UserService.java
@@ -1,0 +1,69 @@
+package com.ogjg.daitgym.s3.service;
+
+import com.ogjg.daitgym.s3.repository.S3Repository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class S3UserService {
+
+    @Value("${cloud.aws.default.profile-img}")
+    private String AWS_DEFAULT_PROFILE_IMG;
+
+    private final S3Repository s3Repository;
+
+    public String saveProfileImage(MultipartFile multipartFile, String currentImageUrl) {
+        // default 이미지 url 사용 시 삭제 방지
+        if (!AWS_DEFAULT_PROFILE_IMG.equals(currentImageUrl)) {
+            s3Repository.deleteImageFromS3(currentImageUrl);
+        }
+
+        String newImgUrl = currentImageUrl;
+
+        // s3에 uuid로 랜덤 이름 생성해서 저장
+        if (isNotEmptyFile(multipartFile)) {
+            newImgUrl = s3Repository.uploadImageToS3(multipartFile);
+        }
+
+        return newImgUrl;
+    }
+
+    private boolean isNotEmptyFile(MultipartFile multipartFile) {
+        return multipartFile != null && !multipartFile.isEmpty();
+    }
+
+    /**
+     * 자격증과 이미지 혹은 수상과 이미지가 모두 값이 존재           -->  s3에 저장하고 url들을 반환
+     * 자격증과 이미지 혹은 수상과 이미지가 모두 null 혹은 비어있다면 -->  빈 리스트 반환
+     */
+    public List<String> saveCareerImages(Collection<?> submitted, List<MultipartFile> imageFiles) {
+        if (!isEmptyCollection(submitted) && !isFileListNull(imageFiles)) {
+            return saveImages(imageFiles);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<String> saveImages(List<MultipartFile> imageFiles) {
+        return imageFiles.stream()
+                .map(s3Repository::uploadImageToS3)
+                .toList();
+    }
+
+    private boolean isEmptyCollection(Collection<?> collection) {
+        return collection == null || collection.isEmpty();
+    }
+
+    // List<MultipartFile>은 빈 파일보내면 길이 1의 리스트를 반환
+    private boolean isFileListNull(List<MultipartFile> imgFiles) {
+        return imgFiles == null || imgFiles.get(0).isEmpty();
+    }
+
+}

--- a/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
+++ b/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
@@ -45,9 +45,10 @@ public class UserController {
      */
     @GetMapping("/check-duplication")
     public ApiResponse<?> checkNicknameDuplication(
-            @RequestParam("nickname") String nickname
+            @RequestParam("nickname") String nickname,
+            @AuthenticationPrincipal OAuth2JwtUserDetails userDetails
     ) {
-        String message = userService.checkNicknameDuplication(nickname);
+        String message = userService.checkNicknameDuplication(nickname, userDetails.getNickname());
         return new ApiResponse<>(ErrorCode.SUCCESS.changeMessage(message));
     }
 

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -84,7 +84,7 @@ public class UserService {
             throw new WrongApproach("본인의 프로필만 수정할 수 있습니다.");
         }
 
-        if (isNicknameAlreadyExist(request.getNickname())) {
+        if (isNicknameAlreadyExist(user.getNickname(), request.getNickname())) {
             throw new AlreadyExistNickname();
         }
 
@@ -221,9 +221,10 @@ public class UserService {
 
     @Transactional
     public EditInitialNicknameResponse editInitialNickname(String loginEmail, EditNicknameRequest request) {
+        User findUser = findUserByEmail(loginEmail);
         String newNickname = request.getNickname();
 
-        if (isNicknameAlreadyExist(newNickname)) {
+        if (isNicknameAlreadyExist(findUser.getNickname(), newNickname)) {
             throw new AlreadyExistNickname();
         }
 
@@ -232,22 +233,20 @@ public class UserService {
             throw new NotFoundUser("존재하지 않는 회원입니다.");
         }
 
-        User findUser = findUserByEmail(loginEmail);
-        String nickname = findUser.changeNickname(newNickname);
-
-        return EditInitialNicknameResponse.of(nickname);
+        String changedNickname = findUser.changeNickname(newNickname);
+        return EditInitialNicknameResponse.of(changedNickname);
     }
 
     @Transactional(readOnly = true)
-    public String checkNicknameDuplication(String nickname) {
-        if (isNicknameAlreadyExist(nickname)) {
+    public String checkNicknameDuplication(String nickname, String newNickname) {
+        if (isNicknameAlreadyExist(nickname, newNickname)) {
             return "중복";
         }
         return "사용가능";
     }
 
-    private boolean isNicknameAlreadyExist(String newNickname) {
-        return userRepository.findByNickname(newNickname).isPresent();
+    private boolean isNicknameAlreadyExist(String nickname, String newNickname) {
+        return !nickname.equals(newNickname) && userRepository.findByNickname(newNickname).isPresent();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -68,12 +68,17 @@ public class UserService {
                 .userProfileImgUrl(targetUser.getImageUrl())
                 .introduction(targetUser.getIntroduction())
                 .healthClubName(targetUser.getHealthClub().getName())
-                .isFollower(followRepository.findByFollowPK(Follow.createFollowPK(targetUser.getEmail(), loginEmail)).isPresent())
+                .isFollower(isTargetUserFollowedByLoginUser(targetUser.getEmail(), loginEmail))
                 .role(targetUser.getRole())
                 .journalCount(exerciseJournalRepository.countByUserEmail(targetUser.getEmail()))
                 .followerCount(followRepository.countByFollowPKTargetEmail(targetUser.getEmail()))
                 .followingCount(followRepository.countByFollowPKFollowerEmail(targetUser.getEmail()))
                 .build();
+    }
+
+    private boolean isTargetUserFollowedByLoginUser(String targetEmail, String loginEmail) {
+        return followRepository.findByFollowPK(Follow.createFollowPK(targetEmail, loginEmail))
+                .isPresent();
     }
 
     @Transactional


### PR DESCRIPTION
### [Refactor : DIG-135 S3Service 생성하여 유저관련 s3 로직 분리](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/65/commits/83fb097d9e5c4d3c7d75fe9b5ee0dadea7f9e906) 
- s3에 image 파일 저장 로직 분리
- img -> images로 통일
- todo
  - 여전히 중복되는 파일, 컬렉션 null 체크 로직 존재
  - CascadeType.ALL 적용

### [Fix : DIG-111 회원 프로필 편집 기능 nickname을 바꾸지 않으면 중복 로직에 걸리는 버그 수정](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/65/commits/e88388b2d1669bca1408711e356f744b7824a249)
- put 메서드라 매번 전체 프로필 정보가 request에 전달돼서 문제가 생겼다.
- 닉네임 중복 체크 시 자신의 닉네임인지도 확인하도록 수정

### [Refactor : DIG-135 회원 프로필 불러오기 기능 메서드 추출](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/65/commits/6e7ce2282ff80efe77b63147f0a2b576efde0b36) 
- isFollwer의 주체가 누군지 헷갈리는 것을 방지하기 위해 메서드 이름으로 의미를 나타냈다.