### PR TITLE
Fix : DIG-66 OAuth2JwtUserDetails에 nickname 추가 및 리팩터링

### DIFF
--- a/src/main/java/com/ogjg/daitgym/config/security/details/OAuth2JwtUserDetails.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/details/OAuth2JwtUserDetails.java
@@ -33,6 +33,7 @@ public class OAuth2JwtUserDetails extends DefaultOAuth2User implements UserDetai
                 "name");
         this.oAuthAttributes = OAuthAttributes.builder()
                 .email(userClaimsDto.getEmail())
+                .nickname(userClaimsDto.getNickname())
                 .build();
     }
 
@@ -57,7 +58,7 @@ public class OAuth2JwtUserDetails extends DefaultOAuth2User implements UserDetai
     }
 
     public String getNickname() {
-        return "";
+        return oAuthAttributes.getNickname();
     }
 
     public String getEmail() {

--- a/src/main/java/com/ogjg/daitgym/config/security/jwt/dto/JwtUserClaimsDto.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/jwt/dto/JwtUserClaimsDto.java
@@ -2,28 +2,26 @@ package com.ogjg.daitgym.config.security.jwt.dto;
 
 import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
 import com.ogjg.daitgym.domain.Role;
+import com.ogjg.daitgym.domain.User;
 import io.jsonwebtoken.Claims;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import static lombok.AccessLevel.PROTECTED;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = PROTECTED)
+@RequiredArgsConstructor
 public class JwtUserClaimsDto {
 
-    private String email;
-    private Role role;
+    private final String email;
 
-    public JwtUserClaimsDto(String email, Role role) {
-        this.email = email;
-        this.role = role;
-    }
+    private final String nickname;
+
+    private final Role role;
 
     public static JwtUserClaimsDto from(OAuth2JwtUserDetails userDetails) {
         return JwtUserClaimsDto.builder()
+                .nickname(userDetails.getNickname())
                 .email(userDetails.getEmail())
                 .role(userDetails.findAnyFirstRole())
                 .build();
@@ -31,10 +29,26 @@ public class JwtUserClaimsDto {
 
     public static JwtUserClaimsDto from(Claims claims) {
         return JwtUserClaimsDto.builder()
+                .nickname((String) claims.get("nickname"))
                 .email((String) claims.get("email"))
                 .role(Role.fromKey((String) claims.get("role")))
                 .build();
+    }
 
+    public static JwtUserClaimsDto from(User user) {
+        return JwtUserClaimsDto.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .build();
+    }
+
+    public static JwtUserClaimsDto defaultClaimsOf(String kakaoEmail, String tempNickname) {
+        return JwtUserClaimsDto.builder()
+                .email(kakaoEmail)
+                .nickname(tempNickname)
+                .role(Role.USER)
+                .build();
     }
 }
 

--- a/src/main/java/com/ogjg/daitgym/config/security/jwt/util/JwtUtils.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/jwt/util/JwtUtils.java
@@ -88,6 +88,7 @@ public class JwtUtils {
         private static Map<String, Object> createClaims(JwtUserClaimsDto jwtUserClaimsDto) {
             return new HashMap<>(Map.of(
                     ISSUER_KEY, ISSUER,
+                    "nickname", jwtUserClaimsDto.getNickname(),
                     "email", jwtUserClaimsDto.getEmail(),
                     "role", jwtUserClaimsDto.getRole().getKey()
             ));

--- a/src/main/java/com/ogjg/daitgym/user/controller/TokenController.java
+++ b/src/main/java/com/ogjg/daitgym/user/controller/TokenController.java
@@ -45,6 +45,7 @@ public class TokenController {
     ) {
         JwtUserClaimsDto claimsDto = JwtUserClaimsDto.builder()
                 .email(tokenTestRequest.email)
+                .nickname(tokenTestRequest.nickname)
                 .role(Role.fromKey(tokenTestRequest.role))
                 .build();
 

--- a/src/main/java/com/ogjg/daitgym/user/dto/KakaoAccountDto.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/KakaoAccountDto.java
@@ -1,6 +1,5 @@
 package com.ogjg.daitgym.user.dto;
 
-import lombok.Data;
 import lombok.Getter;
 
 @Getter
@@ -8,13 +7,13 @@ public class KakaoAccountDto {
 
     private Long id;
     private KakaoAccount kakao_account;
-    @Data
+    @Getter
     public static class KakaoAccount {
 
         private String email;
         private Profile profile;
 
-        @Data
+        @Getter
         public static class Profile {
 
             private String nickname;

--- a/src/main/java/com/ogjg/daitgym/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/LoginResponseDto.java
@@ -1,16 +1,30 @@
 package com.ogjg.daitgym.user.dto;
 
-import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
+import com.ogjg.daitgym.domain.ExerciseSplit;
+import com.ogjg.daitgym.domain.Role;
+import com.ogjg.daitgym.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
 
 @Getter
-@Builder
 @NoArgsConstructor
 public class LoginResponseDto {
+
+    public static final String DEFAULT_HEALTHCLUB_NAME = "";
+    @Value("${cloud.aws.default.profile-img}")
+    private static String AWS_DEFAULT_PROFILE_IMG_URL;
+    public static final String DEFAULT_INTRODUCTION = DEFAULT_HEALTHCLUB_NAME;
+    public static final String DEFAULT_PREFERRED_SPLIT = ExerciseSplit.ONE_DAY.getTitle();
+    private static final boolean ALREADY_JOINED = true;
+    private static final boolean NOT_ALREADY_JOINED = true;
+    private static final boolean DELETED = true;
+    private static final boolean NOT_DELETED = false;
+
+    private boolean isAlreadyJoined;
+
+    private boolean isDeleted;
 
     private String nickname;
 
@@ -22,11 +36,8 @@ public class LoginResponseDto {
 
     private String healthClubName;
 
-    private boolean isAlreadyJoined;
-
     private String role;
 
-    private boolean isDeleted;
 
     @Builder
     public LoginResponseDto(String nickname, String userProfileImgUrl, String preferredSplit, String introduction, String healthClubName, boolean isAlreadyJoined, String role, boolean isDeleted) {
@@ -39,13 +50,46 @@ public class LoginResponseDto {
         this.role = role;
         this.isDeleted = isDeleted;
     }
-
-    public static LoginResponseDto from(OAuth2JwtUserDetails oAuth2UserDetails) {
-        return LoginResponseDto.builder()
-                .nickname(UUID.randomUUID().toString())
-                .userProfileImgUrl("default")
-                .isAlreadyJoined(oAuth2UserDetails.isAlreadyJoined())
+    
+    public static LoginResponseDto newUserResponse(String tempNickname) {
+        return defaultUserInfoBuilder(tempNickname)
+                .isAlreadyJoined(NOT_ALREADY_JOINED)
+                .isDeleted(NOT_DELETED)
                 .build();
+    }
+
+    private static LoginResponseDtoBuilder defaultUserInfoBuilder(String tempNickname) {
+        return LoginResponseDto.builder()
+                .nickname(tempNickname)
+                .userProfileImgUrl(AWS_DEFAULT_PROFILE_IMG_URL)
+                .preferredSplit(DEFAULT_PREFERRED_SPLIT)
+                .introduction(DEFAULT_INTRODUCTION)
+                .healthClubName(DEFAULT_HEALTHCLUB_NAME)
+                .role(Role.USER.getTitle());
+    }
+
+    public static LoginResponseDto deletedUserResponse(User deletedUser) {
+        return findUserInfoBuilder(deletedUser)
+                .isAlreadyJoined(ALREADY_JOINED)
+                .isDeleted(DELETED)
+                .build();
+    }
+
+    public static LoginResponseDto existUserResponse(User existUser) {
+        return findUserInfoBuilder(existUser)
+                .isAlreadyJoined(ALREADY_JOINED)
+                .isDeleted(NOT_DELETED)
+                .build();
+    }
+
+    private static LoginResponseDtoBuilder findUserInfoBuilder(User user) {
+        return LoginResponseDto.builder()
+                .nickname(user.getNickname())
+                .userProfileImgUrl(user.getImageUrl())
+                .preferredSplit(user.getPreferredSplit().getTitleOrDefault())
+                .introduction(user.getIntroduction())
+                .healthClubName(user.getHealthClub().getName())
+                .role(user.getRole().getTitleOrDefault());
     }
 }
 


### PR DESCRIPTION
### [Fix : DIG-66 OAuth2JwtUserDetails에 nickname 추가 및 리팩터링](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/67/commits/68960eb51df175661a7725aa746d1ab80e18553d)
- jwt 토큰에 닉네임 추가
  - OAuthAttributes에 getNickname 구현
  - JwtUserDetails가 nickname을 포함하도록 수정
- (로그인 기능) LoginUserReponseDto, jwtClaimsDto 리팩터링
  - LoginUserReponseDto
    - 정적 생성메서드 사용,빌더 dto 내부로 이동
    - 내부에 user deafault 상수들 정의
    - 반복되는 builder 메서드로 추출
  - jwtClaimsDto
    - 해당 객체 내에서 claim 값을 한번에 수정할 수 있도록 builder를 노출할 로직들을 정적 생성 메서드를 추가해서 캡슐화
  - kakaoTokenDto
    - @Data 어노테이션 제거