### PR TITLE
Fix : DIG-111 로그인 로직 초깃값 버그 수정, Value 주입 방식 변경 및 리팩터링

### DIFF
--- a/src/main/java/com/ogjg/daitgym/user/controller/LoginController.java
+++ b/src/main/java/com/ogjg/daitgym/user/controller/LoginController.java
@@ -2,7 +2,7 @@ package com.ogjg.daitgym.user.controller;
 
 import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
-import com.ogjg.daitgym.user.dto.LoginResponseDto;
+import com.ogjg.daitgym.user.dto.response.LoginResponse;
 import com.ogjg.daitgym.user.service.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ public class LoginController {
     private final AuthService authService;
 
     @GetMapping("/login/oauth2/callback/kakao")
-    public ApiResponse<LoginResponseDto> kakaoLogin(
+    public ApiResponse<LoginResponse> kakaoLogin(
             @RequestParam("code") String code,
             HttpServletResponse httpServletResponse
     ) {

--- a/src/main/java/com/ogjg/daitgym/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/LoginResponseDto.java
@@ -3,6 +3,7 @@ package com.ogjg.daitgym.user.dto;
 import com.ogjg.daitgym.domain.ExerciseSplit;
 import com.ogjg.daitgym.domain.Role;
 import com.ogjg.daitgym.domain.User;
+import jakarta.annotation.PostConstruct;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,9 @@ import org.springframework.beans.factory.annotation.Value;
 public class LoginResponseDto {
 
     public static final String DEFAULT_HEALTHCLUB_NAME = "";
+
     @Value("${cloud.aws.default.profile-img}")
+    private String awsDefaultUrlTemp;
     private static String AWS_DEFAULT_PROFILE_IMG_URL;
     public static final String DEFAULT_INTRODUCTION = DEFAULT_HEALTHCLUB_NAME;
     public static final String DEFAULT_PREFERRED_SPLIT = ExerciseSplit.ONE_DAY.getTitle();
@@ -38,6 +41,10 @@ public class LoginResponseDto {
 
     private String role;
 
+    @PostConstruct
+    public void setUrl() {
+        AWS_DEFAULT_PROFILE_IMG_URL = awsDefaultUrlTemp;
+    }
 
     @Builder
     public LoginResponseDto(String nickname, String userProfileImgUrl, String preferredSplit, String introduction, String healthClubName, boolean isAlreadyJoined, String role, boolean isDeleted) {

--- a/src/main/java/com/ogjg/daitgym/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/LoginResponseDto.java
@@ -13,17 +13,17 @@ import org.springframework.beans.factory.annotation.Value;
 @NoArgsConstructor
 public class LoginResponseDto {
 
-    public static final String DEFAULT_HEALTHCLUB_NAME = "";
+    public static final String DEFAULT_HEALTH_CLUB_NAME = "";
 
     @Value("${cloud.aws.default.profile-img}")
-    private String awsDefaultUrlTemp;
-    private static String AWS_DEFAULT_PROFILE_IMG_URL;
-    public static final String DEFAULT_INTRODUCTION = DEFAULT_HEALTHCLUB_NAME;
+    public String awsDefaultUrlTemp;
+    public static String AWS_DEFAULT_PROFILE_IMG_URL;
+    public static final String DEFAULT_INTRODUCTION = DEFAULT_HEALTH_CLUB_NAME;
     public static final String DEFAULT_PREFERRED_SPLIT = ExerciseSplit.ONE_DAY.getTitle();
-    private static final boolean ALREADY_JOINED = true;
-    private static final boolean NOT_ALREADY_JOINED = true;
-    private static final boolean DELETED = true;
-    private static final boolean NOT_DELETED = false;
+    public static final boolean ALREADY_JOINED = true;
+    public static final boolean NOT_ALREADY_JOINED = true;
+    public static final boolean DELETED = true;
+    public static final boolean NOT_DELETED = false;
 
     private boolean isAlreadyJoined;
 
@@ -71,7 +71,7 @@ public class LoginResponseDto {
                 .userProfileImgUrl(AWS_DEFAULT_PROFILE_IMG_URL)
                 .preferredSplit(DEFAULT_PREFERRED_SPLIT)
                 .introduction(DEFAULT_INTRODUCTION)
-                .healthClubName(DEFAULT_HEALTHCLUB_NAME)
+                .healthClubName(DEFAULT_HEALTH_CLUB_NAME)
                 .role(Role.USER.getTitle());
     }
 

--- a/src/main/java/com/ogjg/daitgym/user/dto/response/KakaoAccountResponse.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/response/KakaoAccountResponse.java
@@ -1,9 +1,9 @@
-package com.ogjg.daitgym.user.dto;
+package com.ogjg.daitgym.user.dto.response;
 
 import lombok.Getter;
 
 @Getter
-public class KakaoAccountDto {
+public class KakaoAccountResponse {
 
     private Long id;
     private KakaoAccount kakao_account;

--- a/src/main/java/com/ogjg/daitgym/user/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,16 @@
+package com.ogjg.daitgym.user.dto.response;
+
+
+import lombok.Getter;
+
+@Getter
+public class KakaoTokenResponse {
+
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private String id_token;
+    private int expires_in;
+    private int refresh_token_expires_in;
+    private String scope;
+}

--- a/src/main/java/com/ogjg/daitgym/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.ogjg.daitgym.user.dto;
+package com.ogjg.daitgym.user.dto.response;
 
 import com.ogjg.daitgym.domain.ExerciseSplit;
 import com.ogjg.daitgym.domain.Role;
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 @Getter
 @NoArgsConstructor
-public class LoginResponseDto {
+public class LoginResponse {
 
     public static final String DEFAULT_HEALTH_CLUB_NAME = "";
 
@@ -47,7 +47,7 @@ public class LoginResponseDto {
     }
 
     @Builder
-    public LoginResponseDto(String nickname, String userProfileImgUrl, String preferredSplit, String introduction, String healthClubName, boolean isAlreadyJoined, String role, boolean isDeleted) {
+    public LoginResponse(String nickname, String userProfileImgUrl, String preferredSplit, String introduction, String healthClubName, boolean isAlreadyJoined, String role, boolean isDeleted) {
         this.nickname = nickname;
         this.userProfileImgUrl = userProfileImgUrl;
         this.preferredSplit = preferredSplit;
@@ -58,15 +58,15 @@ public class LoginResponseDto {
         this.isDeleted = isDeleted;
     }
     
-    public static LoginResponseDto newUserResponse(String tempNickname) {
+    public static LoginResponse newUserResponse(String tempNickname) {
         return defaultUserInfoBuilder(tempNickname)
                 .isAlreadyJoined(NOT_ALREADY_JOINED)
                 .isDeleted(NOT_DELETED)
                 .build();
     }
 
-    private static LoginResponseDtoBuilder defaultUserInfoBuilder(String tempNickname) {
-        return LoginResponseDto.builder()
+    private static LoginResponseBuilder defaultUserInfoBuilder(String tempNickname) {
+        return LoginResponse.builder()
                 .nickname(tempNickname)
                 .userProfileImgUrl(AWS_DEFAULT_PROFILE_IMG_URL)
                 .preferredSplit(DEFAULT_PREFERRED_SPLIT)
@@ -75,22 +75,22 @@ public class LoginResponseDto {
                 .role(Role.USER.getTitle());
     }
 
-    public static LoginResponseDto deletedUserResponse(User deletedUser) {
+    public static LoginResponse deletedUserResponse(User deletedUser) {
         return findUserInfoBuilder(deletedUser)
                 .isAlreadyJoined(ALREADY_JOINED)
                 .isDeleted(DELETED)
                 .build();
     }
 
-    public static LoginResponseDto existUserResponse(User existUser) {
+    public static LoginResponse existUserResponse(User existUser) {
         return findUserInfoBuilder(existUser)
                 .isAlreadyJoined(ALREADY_JOINED)
                 .isDeleted(NOT_DELETED)
                 .build();
     }
 
-    private static LoginResponseDtoBuilder findUserInfoBuilder(User user) {
-        return LoginResponseDto.builder()
+    private static LoginResponseBuilder findUserInfoBuilder(User user) {
+        return LoginResponse.builder()
                 .nickname(user.getNickname())
                 .userProfileImgUrl(user.getImageUrl())
                 .preferredSplit(user.getPreferredSplit().getTitleOrDefault())

--- a/src/main/java/com/ogjg/daitgym/user/service/AuthService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/AuthService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.ogjg.daitgym.config.security.jwt.dto.JwtUserClaimsDto;
+import com.ogjg.daitgym.domain.ExerciseSplit;
 import com.ogjg.daitgym.domain.HealthClub;
 import com.ogjg.daitgym.domain.Role;
 import com.ogjg.daitgym.domain.User;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.ogjg.daitgym.config.security.jwt.util.JwtUtils.*;
+import static com.ogjg.daitgym.user.dto.LoginResponseDto.*;
 
 @Service
 @RequiredArgsConstructor
@@ -78,21 +80,21 @@ public class AuthService {
             JwtUserClaimsDto claimsDto = JwtUserClaimsDto.defaultClaimsOf(kakaoEmail, tempNickname);
             addTokensInHeader(servletResponse, claimsDto);
 
-            return LoginResponseDto.newUserResponse(tempNickname);
+            return newUserResponse(tempNickname);
 
         // 이전에 가입 후 탈퇴한 회원
         } else if (existUser.isDeleted()){
 
             // todo : 가입했다 탈퇴한 회원 처리 -> 탈퇴해서 아이디가 남아있는 회원의 처리가 추가되어야 한다.
 
-            return LoginResponseDto.deletedUserResponse(existUser);
+            return deletedUserResponse(existUser);
 
         // 이전에 이미 가입한 회원 -> 유저정보를 불러온다.
         } else {
             JwtUserClaimsDto claimsDto = JwtUserClaimsDto.from(existUser);
             addTokensInHeader(servletResponse, claimsDto);
 
-            return LoginResponseDto.existUserResponse(existUser);
+            return existUserResponse(existUser);
         }
     }
 
@@ -104,8 +106,12 @@ public class AuthService {
         User user = User.builder()
                 .email(kakaoEmail)
                 .nickname(tempNickname)
+                .imageUrl(AWS_DEFAULT_PROFILE_IMG_URL)
+                .introduction(DEFAULT_INTRODUCTION)
+                .preferredSplit(ExerciseSplit.THREE_DAY)
                 .role(Role.USER)
                 .healthClub(defaultHealthClub)
+                .isDeleted(NOT_DELETED)
                 .build();
 
         userRepository.save(user);


### PR DESCRIPTION
### [Fix : DIG-111 static으로 설정하여](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/46059a4965789f18bfaa73f7255c3b0b0415b0ac) https://github.com/value [값을 전달받지 못하는 오류 수정]
- static으로 사용하면 로딩되는 시점이 일치하지 않아 Value값을 주입받지 못합니다.
- \@PostConstruct를 활용해서 static 변수에 주입했습니다.

### [Fix : DIG-111 누락된 초기 유저 기본 생성 값 추가](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/22f0f38064aca6cecbd02c79e980b32953c5034f)
- 유저 초기 가입시 default 값들이 누락되어 추가했습니다.

### [Refactor : DIG-135 dto 패키지 변경 및 Reponse로 이름 변경](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/69/commits/df62e7acba34563c38d7732208b7c2aefeaecd28)

### todo
- 상수 클래스를 따로만들거나, default 값들에 대한 정리가 필요할 것 같습니다. 우선은 LoginResponseDto에 상수들을 넣어두었습니다.
- 카카오 소셜로그인 부분 리팩터링이 많이 필요합니다. 분리할 로직들이 많습니다.
