### PR TITLE
Feat : DIG-137 관리자 관련 기능 구현 

### DIFF
--- a/src/main/java/com/ogjg/daitgym/admin/controller/AdminController.java
+++ b/src/main/java/com/ogjg/daitgym/admin/controller/AdminController.java
@@ -1,0 +1,34 @@
+package com.ogjg.daitgym.admin.controller;
+
+import com.ogjg.daitgym.admin.dto.response.GetApprovalsResponse;
+import com.ogjg.daitgym.admin.service.AdminService;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admins/approvals")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("")
+    public ApiResponse<GetApprovalsResponse> getApprovals(
+            @RequestParam("nickname") String nickname,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC)
+            Pageable pageable
+    ) {
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                adminService.getApprovals(nickname, pageable)
+        );
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/admin/controller/AdminController.java
+++ b/src/main/java/com/ogjg/daitgym/admin/controller/AdminController.java
@@ -1,19 +1,18 @@
 package com.ogjg.daitgym.admin.controller;
 
+import com.ogjg.daitgym.admin.dto.request.EditApprovalRequest;
 import com.ogjg.daitgym.admin.dto.response.GetApprovalDetailResponse;
 import com.ogjg.daitgym.admin.dto.response.GetApprovalsResponse;
 import com.ogjg.daitgym.admin.service.AdminService;
 import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,4 +42,15 @@ public class AdminController {
                 adminService.getApproval(approvalId)
         );
     }
+
+    @PatchMapping("/{approvalId}")
+    public ApiResponse<Void> handleApproval(
+            @PathVariable("approvalId") Long approvalId,
+            @RequestBody EditApprovalRequest request,
+            @AuthenticationPrincipal OAuth2JwtUserDetails jwtUserDetails
+            ) {
+        adminService.updateApproval(approvalId, request, jwtUserDetails.getEmail());
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
 }

--- a/src/main/java/com/ogjg/daitgym/admin/controller/AdminController.java
+++ b/src/main/java/com/ogjg/daitgym/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.ogjg.daitgym.admin.controller;
 
+import com.ogjg.daitgym.admin.dto.response.GetApprovalDetailResponse;
 import com.ogjg.daitgym.admin.dto.response.GetApprovalsResponse;
 import com.ogjg.daitgym.admin.service.AdminService;
 import com.ogjg.daitgym.common.exception.ErrorCode;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +31,16 @@ public class AdminController {
         return new ApiResponse<>(
                 ErrorCode.SUCCESS,
                 adminService.getApprovals(nickname, pageable)
+        );
+    }
+
+    @GetMapping("/{approvalId}")
+    public ApiResponse<GetApprovalDetailResponse> getApproval(
+            @PathVariable("approvalId") Long approvalId) {
+
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                adminService.getApproval(approvalId)
         );
     }
 }

--- a/src/main/java/com/ogjg/daitgym/admin/dto/request/EditApprovalRequest.java
+++ b/src/main/java/com/ogjg/daitgym/admin/dto/request/EditApprovalRequest.java
@@ -1,0 +1,14 @@
+package com.ogjg.daitgym.admin.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class EditApprovalRequest {
+    private String reason;
+    private String approvalStatus;
+
+    public EditApprovalRequest(String reason, String approvalStatus) {
+        this.reason = reason;
+        this.approvalStatus = approvalStatus;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/admin/dto/response/GetApprovalDetailResponse.java
+++ b/src/main/java/com/ogjg/daitgym/admin/dto/response/GetApprovalDetailResponse.java
@@ -1,0 +1,151 @@
+package com.ogjg.daitgym.admin.dto.response;
+
+import com.ogjg.daitgym.domain.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class GetApprovalDetailResponse {
+
+    private GetApprovalDetail approval;
+    private List<GetApprovalDetailAward> awards;
+    private List<GetApprovalDetailCertification> certifications;
+    private List<String> awardImgs;
+    private List<String> certificationImgs;
+
+    @Builder
+    public GetApprovalDetailResponse(GetApprovalDetail approval, List<GetApprovalDetailAward> awards, List<GetApprovalDetailCertification> certifications, List<String> awardImgs, List<String> certificationImgs) {
+        this.approval = approval;
+        this.awards = awards;
+        this.certifications = certifications;
+        this.awardImgs = awardImgs;
+        this.certificationImgs = certificationImgs;
+    }
+
+    public static GetApprovalDetailResponse from(Approval approval) {
+        return GetApprovalDetailResponse.builder()
+                .approval(GetApprovalDetail.from(approval))
+                .awards(toDetailAwards(approval))
+                .certifications(toDetailCertifcations(approval))
+                .awardImgs(toDetailAwardImageUrls(approval))
+                .certificationImgs(toDetailCertificationImageUrls(approval))
+                .build();
+    }
+
+    private static User findUser(Approval approval) {
+        if (approval.getAwards() == null) {
+            return approval.getCertifications().get(0).getUser();
+        }
+
+        return approval.getAwards().get(0).getUser();
+    }
+
+    private static List<GetApprovalDetailCertification> toDetailCertifcations(Approval approval) {
+        return approval.getCertifications().stream()
+                .map((GetApprovalDetailCertification::from))
+                .toList();
+    }
+
+    private static List<GetApprovalDetailAward> toDetailAwards(Approval approval) {
+        return approval.getAwards().stream()
+                .map((GetApprovalDetailAward::from))
+                .toList();
+    }
+
+    private static List<String> toDetailAwardImageUrls(Approval approval) {
+        return approval.getAwards().stream()
+                .map(Award::getAwardImages)
+                .flatMap(Collection::stream)
+                .map(AwardImage::getUrl)
+                .toList();
+    }
+
+    private static List<String> toDetailCertificationImageUrls(Approval approval) {
+        return approval.getCertifications().stream()
+                .map(Certification::getCertificationImages)
+                .flatMap(Collection::stream)
+                .map(CertificationImage::getUrl)
+                .toList();
+    }
+
+    @Getter
+    public static class GetApprovalDetail {
+        private Long approvalId;
+        private String nickname;
+        private String email;
+        private String approvalStatus;
+        private boolean withdraw;
+        private LocalDate joinAt;
+        private String reason;
+
+        @Builder
+        public GetApprovalDetail(Long approvalId, String nickname, String email, String approvalStatus, boolean withdraw, LocalDate joinAt, String reason) {
+            this.approvalId = approvalId;
+            this.nickname = nickname;
+            this.email = email;
+            this.approvalStatus = approvalStatus;
+            this.withdraw = withdraw;
+            this.joinAt = joinAt;
+            this.reason = reason;
+        }
+
+        public static GetApprovalDetail from(Approval approval) {
+            User user = findUser(approval);
+
+            return GetApprovalDetail.builder()
+                   .approvalId(approval.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .approvalStatus(approval.getApproveStatus().getTitle())
+                .withdraw(user.isDeleted())
+                .joinAt(user.getCreatedAt().toLocalDate())
+                .reason(approval.getContent())
+                .build();
+        }
+    }
+
+    @Getter
+    public static class GetApprovalDetailAward {
+        private String name;
+        private LocalDate awardAt;
+        private String org;
+
+        @Builder
+        public GetApprovalDetailAward(String name, LocalDate awardAt, String org) {
+            this.name = name;
+            this.awardAt = awardAt;
+            this.org = org;
+        }
+
+        public static GetApprovalDetailAward from(Award award) {
+            return GetApprovalDetailAward.builder()
+                    .name(award.getAwardName())
+                    .awardAt(award.getAwardAt())
+                    .org(award.getHostOrganization())
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class GetApprovalDetailCertification {
+        private String name;
+        private LocalDate acquisitionAt; // acquire 변경 요망
+
+        @Builder
+        public GetApprovalDetailCertification(String name, LocalDate acquisitionAt) {
+            this.name = name;
+            this.acquisitionAt = acquisitionAt;
+        }
+
+        public static GetApprovalDetailCertification from(Certification certification) {
+            return GetApprovalDetailCertification.builder()
+                    .name(certification.getName())
+                    .acquisitionAt(certification.getAcquisitionAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/admin/dto/response/GetApprovalsResponse.java
+++ b/src/main/java/com/ogjg/daitgym/admin/dto/response/GetApprovalsResponse.java
@@ -1,0 +1,70 @@
+package com.ogjg.daitgym.admin.dto.response;
+
+import com.ogjg.daitgym.domain.Approval;
+import com.ogjg.daitgym.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class GetApprovalsResponse {
+
+    private final List<GetApprovalResponse> approvals;
+
+    public GetApprovalsResponse(List<GetApprovalResponse> approvals) {
+        this.approvals = approvals;
+    }
+
+    public static GetApprovalsResponse from(List<Approval> approvalPages) {
+        List<GetApprovalResponse> approvals = approvalPages.stream()
+                .map(GetApprovalResponse::from)
+                .toList();
+        return new GetApprovalsResponse(approvals);
+    }
+
+    @Getter
+    private static class GetApprovalResponse {
+        private Long approvalId;
+        private String nickname;
+        private String email;
+        private String role;
+        private String approvalStatus;
+        private boolean withdraw;
+        private LocalDate joinAt;
+
+        @Builder
+        public GetApprovalResponse(Long approvalId, String nickname, String email, String role, String approvalStatus, boolean withdraw, LocalDate joinAt) {
+            this.approvalId = approvalId;
+            this.nickname = nickname;
+            this.email = email;
+            this.role = role;
+            this.approvalStatus = approvalStatus;
+            this.withdraw = withdraw;
+            this.joinAt = joinAt;
+        }
+
+        public static GetApprovalResponse from(Approval approval) {
+            User user = findUser(approval);
+
+            return GetApprovalResponse.builder()
+                    .approvalId(approval.getId())
+                    .nickname(user.getNickname())
+                    .email(user.getEmail())
+                    .role(user.getRole().getTitle())
+                    .approvalStatus(approval.getApproveStatus().getTitle())
+                    .withdraw(user.isDeleted())
+                    .joinAt(user.getCreatedAt().toLocalDate())
+                    .build();
+        }
+
+        private static User findUser(Approval approval) {
+            if (approval.getAwards() == null) {
+                return approval.getCertifications().get(0).getUser();
+            }
+
+            return approval.getAwards().get(0).getUser();
+        }
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/admin/service/AdminService.java
+++ b/src/main/java/com/ogjg/daitgym/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.ogjg.daitgym.admin.service;
 
+import com.ogjg.daitgym.admin.dto.request.EditApprovalRequest;
 import com.ogjg.daitgym.admin.dto.response.GetApprovalDetailResponse;
 import com.ogjg.daitgym.admin.dto.response.GetApprovalsResponse;
 import com.ogjg.daitgym.approval.repository.ApprovalRepository;
@@ -25,12 +26,18 @@ public class AdminService {
 
     @Transactional(readOnly = true)
     public GetApprovalDetailResponse getApproval(Long approvalId) {
-        Approval approval = findByApproval(approvalId);
+        Approval approval = findById(approvalId);
 
         return GetApprovalDetailResponse.from(approval);
     }
 
-    private Approval findByApproval(Long approvalId) {
+    @Transactional
+    public void updateApproval(Long approvalId, EditApprovalRequest request, String loginEmail) {
+        Approval approval = findById(approvalId);
+        approval.edit(request.getApprovalStatus(), request.getReason(), loginEmail);
+    }
+
+    private Approval findById(Long approvalId) {
         return approvalRepository.findById(approvalId)
                 .orElseThrow(NotFoundApproval::new);
     }

--- a/src/main/java/com/ogjg/daitgym/admin/service/AdminService.java
+++ b/src/main/java/com/ogjg/daitgym/admin/service/AdminService.java
@@ -1,7 +1,10 @@
 package com.ogjg.daitgym.admin.service;
 
+import com.ogjg.daitgym.admin.dto.response.GetApprovalDetailResponse;
 import com.ogjg.daitgym.admin.dto.response.GetApprovalsResponse;
 import com.ogjg.daitgym.approval.repository.ApprovalRepository;
+import com.ogjg.daitgym.common.exception.approval.NotFoundApproval;
+import com.ogjg.daitgym.domain.Approval;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -18,5 +21,17 @@ public class AdminService {
         return GetApprovalsResponse.from(
                 approvalRepository.findByUserNickname(nickname + "%", pageable.getPageSize(), pageable.getPageNumber())
         );
+    }
+
+    @Transactional(readOnly = true)
+    public GetApprovalDetailResponse getApproval(Long approvalId) {
+        Approval approval = findByApproval(approvalId);
+
+        return GetApprovalDetailResponse.from(approval);
+    }
+
+    private Approval findByApproval(Long approvalId) {
+        return approvalRepository.findById(approvalId)
+                .orElseThrow(NotFoundApproval::new);
     }
 }

--- a/src/main/java/com/ogjg/daitgym/admin/service/AdminService.java
+++ b/src/main/java/com/ogjg/daitgym/admin/service/AdminService.java
@@ -1,0 +1,22 @@
+package com.ogjg.daitgym.admin.service;
+
+import com.ogjg.daitgym.admin.dto.response.GetApprovalsResponse;
+import com.ogjg.daitgym.approval.repository.ApprovalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final ApprovalRepository approvalRepository;
+
+    @Transactional(readOnly = true)
+    public GetApprovalsResponse getApprovals(String nickname, Pageable pageable) {
+        return GetApprovalsResponse.from(
+                approvalRepository.findByUserNickname(nickname + "%", pageable.getPageSize(), pageable.getPageNumber())
+        );
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/approval/repository/ApprovalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/approval/repository/ApprovalRepository.java
@@ -2,6 +2,31 @@ package com.ogjg.daitgym.approval.repository;
 
 import com.ogjg.daitgym.domain.Approval;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ApprovalRepository extends JpaRepository<Approval, Long> {
+
+    @Query(value = """
+    SELECT * FROM
+    (
+    SELECT a.content, a.approval_manager, a.created_at , a.modified_at, a.id as id, a.approve_status as approve_status 
+        FROM Approval a
+        INNER JOIN certification c ON a.id = c.approval_id
+        INNER JOIN users u ON c.email = u.email
+        WHERE u.nickname LIKE :nickname
+    UNION
+    SELECT a.content, a.approval_manager, a.created_at , a.modified_at, a.id as id, a.approve_status as approve_status 
+        FROM Approval a
+        INNER JOIN award aw ON a.id = aw.approval_id
+        INNER JOIN users u ON aw.email = u.email
+        WHERE u.nickname LIKE :nickname
+    )
+    AS mytable ORDER BY mytable.approve_status ASC, mytable.id ASC LIMIT :limit OFFSET :offset
+    """, nativeQuery = true)
+    List<Approval> findByUserNickname(@Param("nickname") String nicknamePattern, @Param("limit") int limit, @Param("offset") int offset);
 }
+
+

--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode implements ErrorType {
     NOT_FOUND_EXERCISE_LIST(HttpStatus.NOT_FOUND, "404", "운동 목록을 찾을 수 없습니다"),
     NOT_FOUND_EXERCISE_HISTORY(HttpStatus.NOT_FOUND, "404", "운동 기록을 찾을 수 없습니다"),
     NOT_FOUND_APPROVAL(HttpStatus.NOT_FOUND, "404", "승인 요청 내역을 찾을 수 없습니다"),
+    NOT_FOUND_APPROVAL_STATUS(HttpStatus.NOT_FOUND, "404", "해당 title을 가진 승인 상태가 존재하지 않습니다."),
     NOT_FOUND_EXERCISE_COLLECTION(HttpStatus.NOT_FOUND,"404","피드 운동일지 스크랩 기록을 찾을 수 없습니다"),
     NOT_FOUND_JOURNAL(HttpStatus.NOT_FOUND, "404", "운동일지를 찾을 수 없습니다"),
     USER_NOT_AUTHORIZED_JOURNAL(HttpStatus.FORBIDDEN, "403", "운동일지에 접근 권한이 없습니다"),
@@ -41,7 +42,8 @@ public enum ErrorCode implements ErrorType {
     UNAUTHORIZED_USER_ACCESS(HttpStatus.FORBIDDEN, "403", "접근 권한이 부족합니다."),
     NO_EXERCISE_IN_ROUTINE(HttpStatus.NOT_FOUND, "404", "루틴의 운동을 찾을 수 없습니다."),
     EMPTY_TRAINER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "잘못된 승인 신청입니다. 자격 혹은 수상내역 입력이 누락되었습니다."),
-    ALREADY_SCRAPPED_ROUTINE(HttpStatus.BAD_REQUEST, "400", "이미 스크랩한 루틴입니다.");
+    ALREADY_SCRAPPED_ROUTINE(HttpStatus.BAD_REQUEST, "400", "이미 스크랩한 루틴입니다."),
+    ;
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode implements ErrorType {
     NOT_FOUND_EXERCISE_PART(HttpStatus.NOT_FOUND, "404", "운동부위를 찾을 수 없습니다"),
     NOT_FOUND_EXERCISE_LIST(HttpStatus.NOT_FOUND, "404", "운동 목록을 찾을 수 없습니다"),
     NOT_FOUND_EXERCISE_HISTORY(HttpStatus.NOT_FOUND, "404", "운동 기록을 찾을 수 없습니다"),
+    NOT_FOUND_APPROVAL(HttpStatus.NOT_FOUND, "404", "승인 요청 내역을 찾을 수 없습니다"),
     NOT_FOUND_EXERCISE_COLLECTION(HttpStatus.NOT_FOUND,"404","피드 운동일지 스크랩 기록을 찾을 수 없습니다"),
     NOT_FOUND_JOURNAL(HttpStatus.NOT_FOUND, "404", "운동일지를 찾을 수 없습니다"),
     USER_NOT_AUTHORIZED_JOURNAL(HttpStatus.FORBIDDEN, "403", "운동일지에 접근 권한이 없습니다"),

--- a/src/main/java/com/ogjg/daitgym/common/exception/approval/NotFoundApproval.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/approval/NotFoundApproval.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.common.exception.approval;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundApproval extends CustomException {
+    public NotFoundApproval() {
+        super(ErrorCode.NOT_FOUND_APPROVAL);
+    }
+
+    public NotFoundApproval(String message) {
+        super(ErrorCode.NOT_FOUND_APPROVAL, message);
+    }
+
+    public NotFoundApproval(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_APPROVAL, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/approval/NotFoundApprovalStatus.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/approval/NotFoundApprovalStatus.java
@@ -1,0 +1,19 @@
+package com.ogjg.daitgym.common.exception.approval;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundApprovalStatus extends CustomException {
+    public NotFoundApprovalStatus() {
+        super(ErrorCode.NOT_FOUND_APPROVAL_STATUS);
+    }
+
+    public NotFoundApprovalStatus(String message) {
+        super(ErrorCode.NOT_FOUND_APPROVAL, message);
+    }
+
+    public NotFoundApprovalStatus(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_APPROVAL, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/domain/Approval.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Approval.java
@@ -45,4 +45,10 @@ public class Approval extends BaseEntity {
         this.content = content;
         this.approvalManager = approvalManager;
     }
+
+    public void edit(String approveStatus, String reason, String loginEmail) {
+        this.approveStatus = ApproveStatus.from(approveStatus);
+        this.content = reason;
+        // todo : mangerId 등록
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/ApproveStatus.java
+++ b/src/main/java/com/ogjg/daitgym/domain/ApproveStatus.java
@@ -1,6 +1,9 @@
 package com.ogjg.daitgym.domain;
 
+import com.ogjg.daitgym.common.exception.approval.NotFoundApprovalStatus;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Getter
 public enum ApproveStatus {
@@ -9,6 +12,13 @@ public enum ApproveStatus {
     WAITING("승인 대기"), SUSPENSION("보류"), REJECTION("승인 거부"), APPROVAL("트레이너 승인");
 
     private final String title;
+
+    public static ApproveStatus from(String title) {
+        return Arrays.stream(values())
+                .filter((value) -> title.equals(value.title))
+                .findAny()
+                .orElseThrow(NotFoundApprovalStatus::new);
+    }
 
     ApproveStatus(String title) {
         this.title = title;

--- a/src/main/java/com/ogjg/daitgym/domain/ApproveStatus.java
+++ b/src/main/java/com/ogjg/daitgym/domain/ApproveStatus.java
@@ -1,7 +1,16 @@
 package com.ogjg.daitgym.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum ApproveStatus {
 
-    APPROVAL, WAITING, SUSPENSION, REJECTION
+    // 관리자- 승인요청 목록 불러오기에서 1차적으로 enum 배치 순서대로 정렬됩니다.
+    WAITING("승인 대기"), SUSPENSION("보류"), REJECTION("승인 거부"), APPROVAL("트레이너 승인");
 
+    private final String title;
+
+    ApproveStatus(String title) {
+        this.title = title;
+    }
 }


### PR DESCRIPTION
### [Feat : DIG-137 승인 요청 목록 보기 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/68df4a29f9d0d310eee3a325c6db4c8be40fdfab) 
- approveStatus에 title값 추가
  - title 값은 프론트에 내려주는 값
- 승인 요청 목록 보기 기능 구현
  - 페이징 기본 10개씩
  - 1차 정렬 기준 : 승인 대기 -> 보류 -> 트레이너 승인  -> 승인 거부 순으로 정렬
    - ~알파벳 순서로 내림차순 정렬되어 있다.~ 알파벳 순서가 아닌 enum에 선언된 순서로 정렬되고 있습니다.
    - Approval 입장에서 Certification 혹은 award 중 한쪽이 null 일 수 있다.
    - UNION을 사용하고 정렬과 조회를 한번에 하기위해 네이티브 쿼리를 사용했다.
  - 2차 정렬 기준 : ApprovalId 값 오름차순 (심사 요청 생성 일시 기준과 같다.)
### [Feat : DIG-137 승인 요청 상세보기 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/755a51f8a33bd7d81885c98d93dedc3b82591648) 
- 관리자가 승인요청 목록을 보는 곳에서 상세보기하는 기능 구현
- 해당 승인요청이 존재하지 않을때 예외처리
### [Feat : DIG-137 승인 결과 제출 및 수정 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/7b86736d7f849159c4ae3b48613fbd6e3454b767) 
- patch 메서드로 승인 상태를 변경하고 사유를 저장하는 기능 구현
- Oauth2JwtUserDetails에 잘못된 email 반환값 수정

### todo
- 목록보기 네이티브 쿼리를 dto 방식으로 바꿔야 후에 엔티티가 수정되면 오류를 잡기 더 쉬울 것 같습니다.
- 승인한 관리자 넘버를 추가해야합니다.