### PR TITLE
Fix : DIG-13 전체 메세지 조회 버그 수정

### DIFF
--- a/src/main/java/com/ogjg/daitgym/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ogjg/daitgym/chat/service/ChatMessageService.java
@@ -93,10 +93,10 @@ public class ChatMessageService {
         List<ChatMessage> dbMessageList = chatMessageRepository.findAllByRedisRoomIdOrderByMessageCreatedAtAsc(redisRoomId);
 
         for (ChatMessage chatMessage : dbMessageList) {
-            chatMessageDtos.add(new ChatMessageDto(chatMessage, user));
+            User sender = chatMessage.getUser();
+            chatMessageDtos.add(new ChatMessageDto(chatMessage, sender));
         }
         return chatMessageDtos;
-
 
 //        List<ChatMessageDto> redisMessageList = redisTemplateMessage.opsForList().range(redisRoomId, 0, -1);
 //


### PR DESCRIPTION
- ChatMessageService - 전체 메시지 조회시, 상대방의 채팅메세지가 본인걸로 넘어오는 버그 발생
    - 로그인한 유저의 값으로만 넘겨받아 문제가 발생함 
    - 채팅을 보낸 모든 유저의 값을 보내줌