### PR TITLE
Fix, Refactor : 승인 관련 엔티티 CascadeType.ALL, orphanRemoval = true 설정 및 리팩터링

### DIFF
--- a/src/main/java/com/ogjg/daitgym/domain/Approval.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Approval.java
@@ -1,9 +1,6 @@
 package com.ogjg.daitgym.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +8,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -19,14 +17,15 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class Approval extends BaseEntity {
 
+    private static final int FIRST_ELEMENT = 0;
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "approval")
+    @OneToMany(mappedBy = "approval", cascade = ALL, orphanRemoval = true)
     private List<Certification> certifications = new ArrayList<>();
 
-    @OneToMany(mappedBy = "approval")
+    @OneToMany(mappedBy = "approval", cascade = ALL, orphanRemoval = true)
     private List<Award> awards = new ArrayList<>();
 
     private ApproveStatus approveStatus;

--- a/src/main/java/com/ogjg/daitgym/domain/Approval.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Approval.java
@@ -50,4 +50,18 @@ public class Approval extends BaseEntity {
         this.content = reason;
         // todo : mangerId 등록
     }
+
+    public void addAwards(List<Award> awards, List<String> awardImageUrls) {
+        this.awards = awards;
+        awards.stream().forEach((award -> award.addApproval(this)));
+
+        awards.get(FIRST_ELEMENT).addImageUrls(awardImageUrls);
+    }
+
+    public void addCertifications(List<Certification> certifications, List<String> certificationImageUrls) {
+        this.certifications = certifications;
+        certifications.stream().forEach((certification -> certification.addApproval(this)));
+
+        certifications.get(FIRST_ELEMENT).addCertificationImageUrls(certificationImageUrls);
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/Award.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Award.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -26,7 +27,7 @@ public class Award extends BaseEntity {
     @JoinColumn(name = "email")
     private User user;
 
-    @OneToMany(mappedBy = "award")
+    @OneToMany(mappedBy = "award", cascade = ALL, orphanRemoval = true)
     private List<AwardImage> awardImages = new ArrayList<>();
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/ogjg/daitgym/domain/Award.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Award.java
@@ -63,4 +63,16 @@ public class Award extends BaseEntity {
                 .map((awardImage -> awardImage.addAward(this)))
                 .toList();
     }
+
+    public void addApproval(Approval approval) {
+        this.approval = approval;
+    }
+
+    public void addImageUrls(List<String> awardImageUrls) {
+        this.awardImages = awardImageUrls.stream()
+                .map(AwardImage::of)
+                .toList();
+
+        awardImages.stream().forEach(awardImage -> awardImage.addAward(this));
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/AwardImage.java
+++ b/src/main/java/com/ogjg/daitgym/domain/AwardImage.java
@@ -22,6 +22,7 @@ public class AwardImage extends BaseEntity {
     @JoinColumn(name = "award_id")
     private Award award;
 
+    @Column(length = 500)
     private String url;
 
     @Builder

--- a/src/main/java/com/ogjg/daitgym/domain/Certification.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Certification.java
@@ -56,4 +56,16 @@ public class Certification extends BaseEntity {
                 .map((certificationImage -> certificationImage.addCertification(this)))
                 .toList();
     }
+
+    public void addApproval(Approval approval) {
+        this.approval = approval;
+    }
+
+    public void addCertificationImageUrls(List<String> certificationImageUrls) {
+        this.certificationImages = certificationImageUrls.stream()
+                .map(CertificationImage::of)
+                .toList();
+
+        certificationImages.stream().forEach(awardImage -> awardImage.addCertification(this));
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/Certification.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Certification.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -25,7 +26,7 @@ public class Certification extends BaseEntity {
     @JoinColumn(name = "email")
     private User user;
 
-    @OneToMany(mappedBy = "certification")
+    @OneToMany(mappedBy = "certification", cascade = ALL, orphanRemoval = true)
     private List<CertificationImage> certificationImages = new ArrayList<>();
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/ogjg/daitgym/domain/CertificationImage.java
+++ b/src/main/java/com/ogjg/daitgym/domain/CertificationImage.java
@@ -22,6 +22,7 @@ public class CertificationImage extends BaseEntity {
     @JoinColumn(name = "certification_id")
     private Certification certification;
 
+    @Column(length = 500)
     private String url;
 
     @Builder

--- a/src/main/java/com/ogjg/daitgym/user/dto/request/ApplyForApprovalRequest.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/request/ApplyForApprovalRequest.java
@@ -22,6 +22,18 @@ public class ApplyForApprovalRequest {
         this.awards = awards;
     }
 
+    public List<Award> toAwards(User user) {
+        return awards.stream()
+                .map((dto) -> dto.toAward(user))
+                .toList();
+    }
+
+    public List<Certification> toCertifications(User user) {
+        return certifications.stream()
+                .map((dto) -> dto.toCertification(user))
+                .toList();
+    }
+
     @Getter
     @NoArgsConstructor(access = PROTECTED)
     public static class CertificationDto {
@@ -33,23 +45,13 @@ public class ApplyForApprovalRequest {
             this.acquisitionAt = acquisitionAt;
         }
 
-        public Certification toCertification(User user, Approval approval) {
+        public Certification toCertification(User user) {
             return Certification.builder()
                     .user(user)
-                    .approval(approval)
                     .name(this.name)
                     .acquisitionAt(this.acquisitionAt)
                     .certificationImages(new ArrayList<>())
                     .build();
-        }
-
-        private List<CertificationImage> toCertificationImgs(List<String> imgUrls) {
-            return imgUrls.stream()
-                    .map((imgUrl) ->
-                            CertificationImage.builder()
-                                    .url(imgUrl)
-                                    .build())
-                    .toList();
         }
     }
 
@@ -60,25 +62,14 @@ public class ApplyForApprovalRequest {
         private LocalDate awardAt;
         private String org;
 
-        public Award toAward(User user, Approval approval) {
+        public Award toAward(User user) {
             return Award.builder()
                     .user(user)
-                    .approval(approval)
                     .awardName(this.name)
                     .awardAt(this.awardAt)
                     .hostOrganization(this.org)
                     .awardImages(new ArrayList<>())
                     .build();
         }
-
-        private static List<AwardImage> toAwardImages(List<String> imgUrls) {
-            return imgUrls.stream()
-                    .map((imgUrl) ->
-                            AwardImage.builder()
-                                    .url(imgUrl)
-                                    .build()
-                    ).toList();
-        }
-
     }
 }


### PR DESCRIPTION
### [Fix : DIG-137 승인관련 엔티티 CascadeType.ALL, orphanRemoval = true](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/8f6f053e1fa2dced62c4f6ecde27d0a405abf074) 
- 생성과 삭제 주기가 정확히 같아서 ALL로 설정했다.
  - 업데이트 주기는 모호하나, 관리자의 이미지의 삭제가 추가된다해도 주기가 같다.
  - 제출한 회원이 이미지의 수정 및 삭제가 가능해진다면, 설정을 PERSIST,REMOVE만 사용해야 할 수도 있다.
- 이미지 url 길이 임시로 500자 설정

### [Refactor : DIG-135 트레이너 심사 요청 기능 리팩터링](https://github.com/Goorm-OGJG/Da-It-Gym-BE/commit/562845f7ee87cfc4fbde566fcfe42e8e3a5be77c) 
- Cascade.ALL 설정으로 인한 로직 단순화