### PR TITLE
Fix : DIG-148 채팅방 중복 생성 버그 수정 및 필요 없는 코드 삭제

### DIFF
--- a/src/main/java/com/ogjg/daitgym/chat/repository/UsersChattingRoomRepository.java
+++ b/src/main/java/com/ogjg/daitgym/chat/repository/UsersChattingRoomRepository.java
@@ -10,9 +10,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface UsersChattingRoomRepository extends JpaRepository<UsersChattingRoom, Long> {
-    @Query("select u from UsersChattingRoom u where u.user.email in (:email1,:email2)" +
+    @Query("select u from UsersChattingRoom u where u.user.email in (:senderEmail,:receiverEmail)" +
             "group by u.chatRoom having count(u) = 2")
-    List<UsersChattingRoom> findChatRoomByEmails(@Param("email1") String email, @Param("email2") String email2);
+    List<UsersChattingRoom> findChatRoomByEmails(@Param("senderEmail") String senderEmail, @Param("receiverEmail") String receiverEmail);
 
     List<UsersChattingRoom> findAllByUser(User user);
 

--- a/src/main/java/com/ogjg/daitgym/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ogjg/daitgym/chat/service/ChatMessageService.java
@@ -12,7 +12,6 @@ import com.ogjg.daitgym.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,14 +78,10 @@ public class ChatMessageService {
      * 전체 메세지 로드하기
      * Connect 되어 두사람이 채팅방에 있을 때, readCount가 0이 되어야하기 때문에 redis에 저장된 readCount값이 1이라면 0으로 바꿔준다.
      * Long size 란 채팅방에 접속해있는 인원을 의미한다.
-     * <p>
-     * TODO 2023-11-18 고예진 : Redis 채팅 가져오기, 페이징 처리 추가 예정
      */
     @Transactional
     public List<ChatMessageDto> loadMessage(String redisRoomId, User user) {
 
-//        SetOperations<String, Object> setOperations = redisTemplate.opsForSet();
-//        Long size = setOperations.size(redisRoomId + "set");
         updateReadCount(redisRoomId, user);
 
         List<ChatMessageDto> chatMessageDtos = new ArrayList<>();
@@ -97,31 +92,6 @@ public class ChatMessageService {
             chatMessageDtos.add(new ChatMessageDto(chatMessage, sender));
         }
         return chatMessageDtos;
-
-//        List<ChatMessageDto> redisMessageList = redisTemplateMessage.opsForList().range(redisRoomId, 0, -1);
-//
-//        if (redisMessageList == null || redisMessageList.isEmpty() || redisMessageList.size() < dbMessageList.size()) {
-//
-//            for (int i = 0; i < redisMessageList.size(); i++) {
-//                ChatMessageDto chatMessageDto = new ChatMessageDto(dbMessageList.get(i), user);
-//                chatMessageDtos.add(chatMessageDto);
-//                redisTemplateMessage.opsForList().set(redisRoomId, i, chatMessageDto);
-//            }
-//            for (int i = redisMessageList.size(); i < dbMessageList.size(); i++) {
-//                ChatMessageDto chatMessageDto = new ChatMessageDto(dbMessageList.get(i), user);
-//                chatMessageDtos.add(chatMessageDto);
-//                redisTemplateMessage.opsForList().rightPush(redisRoomId, chatMessageDto);
-//            }
-//
-//        } else {
-//            for (int i = 0; i < redisMessageList.size(); i++) {
-//                if (redisMessageList.get(i).getReadCount() == 1 && size == 2) {
-//                    redisMessageList.get(i).setReadCount(0);
-//                    redisTemplateMessage.opsForList().set(redisRoomId, i, redisMessageList.get(i));
-//                }
-//            }
-//            chatMessageDtos.addAll(redisMessageList);
-//        }
     }
 
     /**

--- a/src/main/java/com/ogjg/daitgym/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ogjg/daitgym/chat/service/ChatRoomService.java
@@ -57,7 +57,7 @@ public class ChatRoomService {
         User receiver = getUserNickname(createChatRoomRequest.getReceiver());
         List<UsersChattingRoom> usersChattingRooms = usersChattingRoomRepository.findChatRoomByEmails(sender.getEmail(), receiver.getEmail());
 
-        if (usersChattingRooms.size() == 2) {
+        if (!usersChattingRooms.isEmpty()) {
             return new ChatRoomResponse(usersChattingRooms.get(0).getChatRoom().getRedisRoomId());
         } else {
 


### PR DESCRIPTION
- **ChatRoomService** 
    - 메세지 생성할 때, 메세지 생성하기 버튼을 누를 때마다 채팅방이 생성되는 버그 발생 -> usersChattingRooms.size==2가 아닌 usersChattingRooms가 비어있지 않을 때는 생성된 방 Id값을 반환한다.
    
- **UsersChattingRoomRepository** 
    - Param명을 더 명확하게 수정 : email1 -> senderEmail, email2 -> receiverEmail
    
- **ChatMessageService**
    - loadMessage 는 전체 DB에서 한번에 가져오기로 함 -> TODO 삭제