### PR TITLE
Fix : 임시 admin 접근 권한 허용

### DIFF
--- a/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
+++ b/src/main/java/com/ogjg/daitgym/config/security/SecurityConfig.java
@@ -79,9 +79,9 @@ public class SecurityConfig {
                         authorize -> authorize
                                 .requestMatchers(CorsUtils::isPreFlightRequest)
                                 .permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/**")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/admins/**")).hasRole(Role.ADMIN.name())
                                 .requestMatchers(new AntPathRequestMatcher("/api/trainers/**")).hasRole(Role.TRAINER.name())
-                                .requestMatchers(new AntPathRequestMatcher("/**")).permitAll()
                                 .anyRequest().authenticated()
                 ).exceptionHandling((exceptionHandle) -> exceptionHandle
                         .accessDeniedHandler(accessDeniedHandler)


### PR DESCRIPTION
- 포스트맨으로는 되는데 로컬에서 admin 요청에 접근 시 403에러가 발생합니다.
- 아직 원인을 찾지 못했는데, 프론트 admin 테스트를 위해 우선 임시로 권한설정을 제거했습니다.

```java
.requestMatchers(new AntPathRequestMatcher("/**")).permitAll()
.requestMatchers(new AntPathRequestMatcher("/api/admins/**")).hasRole(Role.ADMIN.name())
.requestMatchers(new AntPathRequestMatcher("/api/trainers/**")).hasRole(Role.TRAINER.name())
```
위처럼 모든 요청을 허용하는 matcher를 맨 위에 위치시켜서 우선처리하도록 변경했습니다. 현재 모든 요청에 권한이 필요없습니다.