### PR TITLE
Feat : DIG-83 회원 관련 기능 버그 수정 및 기능 추가

### DIFF
--- a/src/main/java/com/ogjg/daitgym/approval/repository/AwardRepository.java
+++ b/src/main/java/com/ogjg/daitgym/approval/repository/AwardRepository.java
@@ -3,5 +3,8 @@ package com.ogjg.daitgym.approval.repository;
 import com.ogjg.daitgym.domain.Award;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AwardRepository extends JpaRepository<Award, Long> {
+    List<Award> findByUserEmail(String email);
 }

--- a/src/main/java/com/ogjg/daitgym/approval/repository/CertificationRepository.java
+++ b/src/main/java/com/ogjg/daitgym/approval/repository/CertificationRepository.java
@@ -1,7 +1,11 @@
 package com.ogjg.daitgym.approval.repository;
 
 import com.ogjg.daitgym.domain.Certification;
+import com.ogjg.daitgym.domain.CertificationImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CertificationRepository extends JpaRepository<Certification, Long> {
+    List<Certification> findByUserEmail(String email);
 }

--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -51,7 +51,7 @@ public enum ErrorCode implements ErrorType {
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "400", "중복되는 닉네임입니다."),
     EMPTY_TRAINER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "잘못된 승인 신청입니다. 자격 혹은 수상내역 입력이 누락되었습니다."),
     ALREADY_SCRAPPED_ROUTINE(HttpStatus.BAD_REQUEST, "400", "이미 스크랩한 루틴입니다."),
-    ;
+    ALREADY_PROCEEDING_APPROVAL(HttpStatus.BAD_REQUEST, "400", "이미 심사가 진행중입니다."),;
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/src/main/java/com/ogjg/daitgym/common/exception/user/AlreadyProceedingApproval.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/user/AlreadyProceedingApproval.java
@@ -1,0 +1,20 @@
+package com.ogjg.daitgym.common.exception.user;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class AlreadyProceedingApproval extends CustomException {
+
+    public AlreadyProceedingApproval() {
+        super(ErrorCode.ALREADY_PROCEEDING_APPROVAL);
+    }
+
+    public AlreadyProceedingApproval(String message) {
+        super(ErrorCode.ALREADY_PROCEEDING_APPROVAL, message);
+    }
+
+    public AlreadyProceedingApproval(ErrorData errorData) {
+        super(ErrorCode.ALREADY_PROCEEDING_APPROVAL, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/domain/Approval.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Approval.java
@@ -64,4 +64,8 @@ public class Approval extends BaseEntity {
 
         certifications.get(FIRST_ELEMENT).addCertificationImageUrls(certificationImageUrls);
     }
+
+    public boolean isProceeding() {
+        return approveStatus == ApproveStatus.WAITING || approveStatus == ApproveStatus.SUSPENSION;
+    }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/Inbody.java
+++ b/src/main/java/com/ogjg/daitgym/domain/Inbody.java
@@ -1,5 +1,6 @@
 package com.ogjg.daitgym.domain;
 
+import com.ogjg.daitgym.domain.routine.Routine;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,8 +37,11 @@ public class Inbody extends BaseEntity {
 
     private LocalDate measureAt;
 
+    @ManyToOne(fetch = LAZY)
+    private Routine routine;
+
     @Builder
-    public Inbody(Long id, User user, int score, double skeletalMuscleMass, double bodyFatRatio, double weight, int basalMetabolicRate, LocalDate measureAt) {
+    public Inbody(Long id, User user, int score, double skeletalMuscleMass, double bodyFatRatio, double weight, int basalMetabolicRate, LocalDate measureAt, Routine routine) {
         this.id = id;
         this.user = user;
         this.score = score;
@@ -46,5 +50,6 @@ public class Inbody extends BaseEntity {
         this.weight = weight;
         this.basalMetabolicRate = basalMetabolicRate;
         this.measureAt = measureAt;
+        this.routine = routine;
     }
 }

--- a/src/main/java/com/ogjg/daitgym/domain/User.java
+++ b/src/main/java/com/ogjg/daitgym/domain/User.java
@@ -3,6 +3,7 @@ package com.ogjg.daitgym.domain;
 import com.ogjg.daitgym.domain.routine.Routine;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,6 +37,7 @@ public class User extends BaseEntity {
     @JoinColumn(name = "active_routine_id")
     private Routine activeRoutine;
 
+    @Pattern(regexp = "^[a-zA-Z0-9_]{3,36}$", message = "닉네임은 영문, 숫자, _ 만 사용 가능하며, 길이는 3자 이상 36자 이하여야 합니다.")
     @Column(unique = true)
     private String nickname;
 

--- a/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
+++ b/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
@@ -9,13 +9,12 @@ import com.ogjg.daitgym.user.dto.request.ApplyForApprovalRequest;
 import com.ogjg.daitgym.user.dto.request.EditNicknameRequest;
 import com.ogjg.daitgym.user.dto.request.EditUserProfileRequest;
 import com.ogjg.daitgym.user.dto.request.RegisterInbodyRequest;
-import com.ogjg.daitgym.user.dto.response.EditInitialNicknameResponse;
-import com.ogjg.daitgym.user.dto.response.EditUserProfileResponse;
-import com.ogjg.daitgym.user.dto.response.GetInbodiesResponse;
-import com.ogjg.daitgym.user.dto.response.GetUserProfileGetResponse;
+import com.ogjg.daitgym.user.dto.response.*;
 import com.ogjg.daitgym.user.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -155,6 +154,21 @@ public class UserController {
         return new ApiResponse<>(
                 ErrorCode.SUCCESS,
                 userService.getInbodies(nickname)
+        );
+    }
+
+    /**
+     * 유저 검색
+     */
+    @GetMapping("/search")
+    public ApiResponse<GetSearchUsersResponse> getUsers(
+            @RequestParam("nickname") String nickname,
+            @PageableDefault(page = 0, size = 10) Pageable pageable
+    ) {
+
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                userService.getSearchedUsers(nickname, pageable)
         );
     }
 }

--- a/src/main/java/com/ogjg/daitgym/user/dto/request/EditNicknameRequest.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/request/EditNicknameRequest.java
@@ -1,5 +1,6 @@
 package com.ogjg.daitgym.user.dto.request;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class EditNicknameRequest {
 
+    @Pattern(regexp = "^[a-zA-Z0-9_]{3,11}$", message = "닉네임은 영문, 숫자, _ 만 사용 가능하며, 길이는 3자 이상 11자 이하여야 합니다.")
     private String nickname;
 
     @Builder

--- a/src/main/java/com/ogjg/daitgym/user/dto/request/EditUserProfileRequest.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/request/EditUserProfileRequest.java
@@ -1,6 +1,7 @@
 package com.ogjg.daitgym.user.dto.request;
 
 import com.ogjg.daitgym.domain.HealthClub;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,7 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class EditUserProfileRequest {
 
+    @Pattern(regexp = "^[a-zA-Z0-9_]{3,11}$", message = "닉네임은 영문, 숫자, _ 만 사용 가능하며, 길이는 3자 이상 11자 이하여야 합니다.")
     private String nickname;
     private String introduction;
     private String gymName;

--- a/src/main/java/com/ogjg/daitgym/user/dto/request/RegisterInbodyRequest.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/request/RegisterInbodyRequest.java
@@ -17,4 +17,5 @@ public class RegisterInbodyRequest {
     private double bodyFatRatio ;
     private double weight;
     private int basalMetabolicRate;
+    private Long routineId;
 }

--- a/src/main/java/com/ogjg/daitgym/user/dto/response/GetSearchUsersResponse.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/response/GetSearchUsersResponse.java
@@ -1,0 +1,47 @@
+package com.ogjg.daitgym.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class GetSearchUsersResponse {
+
+    private List<GetSearchUserResponse> userResponses;
+    private boolean hasNext;
+
+    public GetSearchUsersResponse(List<GetSearchUserResponse> userResponses, boolean hasNext) {
+        this.userResponses = userResponses;
+        this.hasNext = hasNext;
+    }
+
+
+    public static GetSearchUsersResponse from(List<GetSearchUserResponse> searchUsersResponse, boolean hasNext) {
+        return new GetSearchUsersResponse(searchUsersResponse, hasNext);
+    }
+
+    @Getter
+    @NoArgsConstructor(access = PROTECTED)
+    public static class GetSearchUserResponse {
+        private String userProfileImageUrl;
+        private String nickname;
+        private String introduction;
+        private int inbodyScore;
+
+        @Builder
+        public GetSearchUserResponse(String userProfileImageUrl, String nickname, String introduction, int inbodyScore) {
+            this.userProfileImageUrl = userProfileImageUrl;
+            this.nickname = nickname;
+            this.introduction = introduction;
+            this.inbodyScore = inbodyScore;
+        }
+    }
+
+
+}

--- a/src/main/java/com/ogjg/daitgym/user/dto/response/GetUserProfileGetResponse.java
+++ b/src/main/java/com/ogjg/daitgym/user/dto/response/GetUserProfileGetResponse.java
@@ -1,6 +1,5 @@
 package com.ogjg.daitgym.user.dto.response;
 
-import com.ogjg.daitgym.domain.Role;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,18 +20,22 @@ public class GetUserProfileGetResponse {
     private int journalCount;
     private int followerCount;
     private int followingCount;
+    private boolean isMyProfile;
+    private boolean submitTrainerQualification;
 
     @Builder
-    public GetUserProfileGetResponse(String nickname, String preferredSplit, String userProfileImgUrl, String introduction, String healthClubName, boolean isFollower, Role role, int journalCount, int followerCount, int followingCount) {
+    public GetUserProfileGetResponse(String nickname, String preferredSplit, String userProfileImgUrl, String introduction, String healthClubName, boolean isFollower, String role, int journalCount, int followerCount, int followingCount, boolean isMyProfile, boolean submitTrainerQualification) {
         this.nickname = nickname;
         this.preferredSplit = preferredSplit;
         this.userProfileImgUrl = userProfileImgUrl;
         this.introduction = introduction;
         this.healthClubName = healthClubName;
         this.isFollower = isFollower;
-        this.role = role.getTitle();
+        this.role = role;
         this.journalCount = journalCount;
         this.followerCount = followerCount;
         this.followingCount = followingCount;
+        this.isMyProfile = isMyProfile;
+        this.submitTrainerQualification = submitTrainerQualification;
     }
 }

--- a/src/main/java/com/ogjg/daitgym/user/repository/UserRepository.java
+++ b/src/main/java/com/ogjg/daitgym/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.ogjg.daitgym.user.repository;
 
 import com.ogjg.daitgym.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +19,7 @@ public interface UserRepository extends JpaRepository<User,String> {
     select u from User u where u.email = :email
 """)
     Optional<User> findByEmailIncludingDeleted(@Param("email") String email);
+
+
+    Page<User> findByNicknameStartingWith(String nickname, Pageable pageable);
 }

--- a/src/main/java/com/ogjg/daitgym/user/service/UserHelper.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserHelper.java
@@ -1,0 +1,34 @@
+package com.ogjg.daitgym.user.service;
+
+import com.ogjg.daitgym.common.exception.user.NotFoundUser;
+import com.ogjg.daitgym.domain.User;
+import com.ogjg.daitgym.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserHelper {
+
+    private final UserRepository userRepository;
+
+    public User findUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
+                .orElseThrow(NotFoundUser::new);
+    }
+
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(NotFoundUser::new);
+    }
+
+    public boolean isUserNotFoundByEmail(String loginEmail) {
+        return !userRepository.findByEmail(loginEmail).isPresent();
+    }
+
+    public boolean isNicknameAlreadyExist(String nickname, String newNickname) {
+        return !nickname.equals(newNickname) && userRepository.findByNickname(newNickname).isPresent();
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.ogjg.daitgym.approval.repository.AwardRepository;
 import com.ogjg.daitgym.approval.repository.CertificationRepository;
 import com.ogjg.daitgym.comment.feedExerciseJournal.exception.WrongApproach;
 import com.ogjg.daitgym.common.exception.user.AlreadyExistNickname;
+import com.ogjg.daitgym.common.exception.user.AlreadyProceedingApproval;
 import com.ogjg.daitgym.common.exception.user.EmptyTrainerApplyException;
 import com.ogjg.daitgym.common.exception.user.NotFoundUser;
 import com.ogjg.daitgym.domain.Approval;
@@ -156,6 +157,9 @@ public class UserService {
     public void applyForApproval(String loginEmail, ApplyForApprovalRequest request, List<MultipartFile> awardImageFiles, List<MultipartFile> certificationImageFiles) {
         User user = userHelper.findUserByEmail(loginEmail);
 
+        if (hasProceedingApproval(user)) {
+            throw new AlreadyProceedingApproval();
+        }
         validateOmission(request, awardImageFiles, certificationImageFiles);
 
         // s3에 이미지들 저장

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.ogjg.daitgym.approval.repository.ApprovalRepository;
 import com.ogjg.daitgym.approval.repository.AwardRepository;
 import com.ogjg.daitgym.approval.repository.CertificationRepository;
 import com.ogjg.daitgym.comment.feedExerciseJournal.exception.WrongApproach;
+import com.ogjg.daitgym.comment.routine.exception.NotFoundRoutine;
 import com.ogjg.daitgym.common.exception.user.AlreadyExistNickname;
 import com.ogjg.daitgym.common.exception.user.AlreadyProceedingApproval;
 import com.ogjg.daitgym.common.exception.user.EmptyTrainerApplyException;
@@ -13,8 +14,10 @@ import com.ogjg.daitgym.domain.HealthClub;
 import com.ogjg.daitgym.domain.Inbody;
 import com.ogjg.daitgym.domain.User;
 import com.ogjg.daitgym.domain.follow.Follow;
+import com.ogjg.daitgym.domain.routine.Routine;
 import com.ogjg.daitgym.follow.repository.FollowRepository;
 import com.ogjg.daitgym.journal.repository.journal.ExerciseJournalRepository;
+import com.ogjg.daitgym.routine.repository.RoutineRepository;
 import com.ogjg.daitgym.s3.service.S3UserService;
 import com.ogjg.daitgym.user.dto.request.ApplyForApprovalRequest;
 import com.ogjg.daitgym.user.dto.request.EditNicknameRequest;
@@ -58,6 +61,8 @@ public class UserService {
     private final CertificationRepository certificationRepository;
 
     private final InbodyRepository inbodyRepository;
+
+    private final RoutineRepository routineRepository;
 
     private final ExerciseJournalRepository exerciseJournalRepository;
 
@@ -207,6 +212,8 @@ public class UserService {
     @Transactional
     public void registerInbody(String loginEmail, RegisterInbodyRequest request) {
         User user = userHelper.findUserByEmail(loginEmail);
+        Routine routine = routineRepository.findById(request.getRoutineId())
+                .orElseThrow(NotFoundRoutine::new);
 
         Inbody inbody = Inbody.builder()
                 .user(user)
@@ -216,6 +223,7 @@ public class UserService {
                 .bodyFatRatio(request.getBodyFatRatio())
                 .weight(request.getWeight())
                 .basalMetabolicRate(request.getBasalMetabolicRate())
+                .routine(routine)
                 .build();
 
         inbodyRepository.save(inbody);

--- a/src/main/java/com/ogjg/daitgym/user/service/UserService.java
+++ b/src/main/java/com/ogjg/daitgym/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.ogjg.daitgym.user.service;
 
-import com.ogjg.daitgym.approval.repository.*;
+import com.ogjg.daitgym.approval.repository.ApprovalRepository;
 import com.ogjg.daitgym.comment.feedExerciseJournal.exception.WrongApproach;
 import com.ogjg.daitgym.common.exception.user.AlreadyExistNickname;
 import com.ogjg.daitgym.common.exception.user.EmptyTrainerApplyException;
@@ -21,7 +21,6 @@ import com.ogjg.daitgym.user.dto.response.*;
 import com.ogjg.daitgym.user.repository.HealthClubRepository;
 import com.ogjg.daitgym.user.repository.InbodyRepository;
 import com.ogjg.daitgym.user.repository.UserRepository;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,15 +42,6 @@ public class UserService {
 
     private final HealthClubRepository healthClubRepository;
 
-    private final CertificationRepository certificationRepository;
-
-    private final AwardRepository awardRepository;
-
-    private final AwardImageRepository awardImageRepository;
-
-    private final CertificationImageRepository certificationImageRepository;
-
-    private final EntityManager em;
     private final FollowRepository followRepository;
 
     private final ApprovalRepository approvalRepository;


### PR DESCRIPTION
### [Feat : DIG-83 회원 닉네임 검색 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/87/commits/96375af0d098e2947d8168bec3da7f444730ffd3) 
- 회원 정보, 인바디 점수 및 마지막 페이지 여부 반환

### [Refactor : UserService에 사용하지 않는 의존성 제거](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/87/commits/c7911ddd23ed1e9e575e5bf490636db463c08cd6)
- 이전 리팩토링으로 인해 사용하지 않는 respository 의존성들 제거

### [Feat : DIG-83 프로필 조회 응답값 추가 및 UserHelper 추가](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/87/commits/cceca3e454478aef459ed8476ca4e81cea62d28f) 

- 내 프로필인지 여부
- 심사가 진행중인지 여부
  - 최신 심사 항목 1개를 조회해서 승인 대기중이거나 보류라면 진행중으로 처리한다.
  - 승인 대기중이거나 보류인 경우가 있으면 추가로 심사요청을 하지 못하게 막아야 한다.
- UserHelper 추가
  - 반복되는 조회로직 제거

### [Feat : DIG-83 이미 심사가 진행중이라면 심사 요청 불가하도록 기능 구현](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/87/commits/b1032becee8807a0d7215a1b5bc39c74f796d9b4)
- 최신 심사 항목 1개를 조회해서 승인 대기중이거나 보류라면 진행중으로 처리하여 추가 심사가 불가능하다.

### [Feat : DIG-83 인바디 정보 저장시 루틴 id 같이 저장하도록 변경](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/87/commits/82840736825e2c19e1614cb0bbad48ca2568713d) 
- inbody 엔티티에 routineId 단방향으로 fk 추가
- request에 id 받아오도록 변경

### [Feat : DIG-83 닉네임 Pattern 추가](https://github.com/Goorm-OGJG/Da-It-Gym-BE/pull/87/commits/4b25002fd410eeeaaa8f2afc6874c291b1d6e1fc) 
- 초기 uuid 닉네임을 고려하여 user 엔티티의 nickname에는 3-36 길이가 가능하도록 설정
- 나머지 수정 요청의 nickname은 3-11 까지만 허용