### PR TITLE
Feat : DIG-161 운동일지 웹푸시 알람보내기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ application-prod.yml
 application-oauth.yml
 TestDatainit.java
 src/main/generated/
+daitgym-firebase-sdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,11 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.20.56')
 	implementation 'software.amazon.awssdk:s3'
 
+	// 웹푸시
+	implementation 'com.google.firebase:firebase-admin:6.8.1'
+	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
+
+
 }
 
 clean {

--- a/src/main/java/com/ogjg/daitgym/DaItGymApplication.java
+++ b/src/main/java/com/ogjg/daitgym/DaItGymApplication.java
@@ -3,9 +3,11 @@ package com.ogjg.daitgym;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class DaItGymApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/ogjg/daitgym/alarm/controller/fcm/NotificationApiController.java
+++ b/src/main/java/com/ogjg/daitgym/alarm/controller/fcm/NotificationApiController.java
@@ -1,0 +1,28 @@
+package com.ogjg.daitgym.alarm.controller.fcm;
+
+import com.ogjg.daitgym.alarm.dto.FcmTokenRequestDto;
+import com.ogjg.daitgym.alarm.service.FcmAlarmService;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.response.ApiResponse;
+import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notification")
+public class NotificationApiController {
+
+    private final FcmAlarmService notificationService;
+
+    @PostMapping("/token")
+    public ApiResponse<Void> saveNotification(@RequestBody FcmTokenRequestDto fcmTokenRequestDto,
+                                              @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails) {
+        notificationService.saveNotification(fcmTokenRequestDto, oAuth2JwtUserDetails);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/alarm/dto/FcmTokenRequestDto.java
+++ b/src/main/java/com/ogjg/daitgym/alarm/dto/FcmTokenRequestDto.java
@@ -1,0 +1,12 @@
+package com.ogjg.daitgym.alarm.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FcmTokenRequestDto {
+    private String token;
+}

--- a/src/main/java/com/ogjg/daitgym/alarm/dto/NotificationRequestDto.java
+++ b/src/main/java/com/ogjg/daitgym/alarm/dto/NotificationRequestDto.java
@@ -1,0 +1,25 @@
+package com.ogjg.daitgym.alarm.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = PROTECTED)
+public class NotificationRequestDto {
+
+    private String title;
+    private String message;
+    private String token;
+
+    @Builder
+    public NotificationRequestDto(String title, String message, String token) {
+        this.title = title;
+        this.message = message;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/alarm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/ogjg/daitgym/alarm/repository/FcmTokenRepository.java
@@ -1,0 +1,14 @@
+package com.ogjg.daitgym.alarm.repository;
+
+import com.ogjg.daitgym.domain.FcmToken;
+import com.ogjg.daitgym.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    boolean existsByUserAndToken(User user, String token);
+
+    Optional<FcmToken> findByUserAndToken(User user, String token);
+}

--- a/src/main/java/com/ogjg/daitgym/alarm/service/FCMInitializer.java
+++ b/src/main/java/com/ogjg/daitgym/alarm/service/FCMInitializer.java
@@ -1,0 +1,39 @@
+package com.ogjg.daitgym.alarm.service;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+public class FCMInitializer {
+
+    @Value("${firebase.sdk.path}")
+    private String FIREBASE_CONFIG_PATH;
+
+    /**
+     * ClassPathResource()는 resources 폴더 아래에 있는 괄호 안 경로를 찾는다.
+     * 우리가 이동시킨 json파일을 찾아서 맞는 정보인지 확인한 후 FirebaseApp.initializeApp()을 통해서 실행한다.
+     */
+    @PostConstruct
+    public void initialize() {
+        try {
+            GoogleCredentials googleCredentials = GoogleCredentials
+                    .fromStream(new ClassPathResource(FIREBASE_CONFIG_PATH).getInputStream());
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(googleCredentials)
+                    .build();
+            FirebaseApp.initializeApp(options);
+        } catch (IOException e) {
+            log.info("FCM error");
+            log.error("FCM error message : " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/alarm/service/FcmAlarmService.java
+++ b/src/main/java/com/ogjg/daitgym/alarm/service/FcmAlarmService.java
@@ -1,0 +1,115 @@
+package com.ogjg.daitgym.alarm.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushNotification;
+import com.ogjg.daitgym.alarm.dto.FcmTokenRequestDto;
+import com.ogjg.daitgym.alarm.dto.NotificationRequestDto;
+import com.ogjg.daitgym.alarm.repository.FcmTokenRepository;
+import com.ogjg.daitgym.common.exception.exercise.NotFoundExercise;
+import com.ogjg.daitgym.common.exception.fcmtoken.NotFoundFcmToken;
+import com.ogjg.daitgym.common.exception.journal.NotFoundExerciseList;
+import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
+import com.ogjg.daitgym.domain.FcmToken;
+import com.ogjg.daitgym.domain.User;
+import com.ogjg.daitgym.domain.exercise.Exercise;
+import com.ogjg.daitgym.domain.journal.ExerciseJournal;
+import com.ogjg.daitgym.domain.journal.ExerciseList;
+import com.ogjg.daitgym.exercise.repository.ExerciseRepository;
+import com.ogjg.daitgym.journal.repository.exerciselist.ExerciseListRepository;
+import com.ogjg.daitgym.user.service.UserHelper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmAlarmService {
+
+    private final UserHelper userHelper;
+    private final ExerciseRepository exerciseRepository;
+    private final FcmTokenRepository notificationRepository;
+    private final ExerciseListRepository exerciseListRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+
+    /**
+     * FCM 토큰값 저장
+     */
+    @Transactional
+    public void saveNotification(FcmTokenRequestDto fcmTokenRequestDto, OAuth2JwtUserDetails oAuth2JwtUserDetails) {
+        User user = userHelper.findUserByEmail(oAuth2JwtUserDetails.getEmail());
+
+        String token = fcmTokenRequestDto.getToken();
+
+        if (!fcmTokenRepository.existsByUserAndToken(user, token)) {
+            FcmToken notification = FcmToken.builder()
+                    .token(token)
+                    .user(user)
+                    .build();
+            notificationRepository.save(notification);
+        } else {
+            log.info("이미 토큰이 존재합니다.");
+        }
+    }
+
+
+    public String alarmMessage(ExerciseJournal exerciseJournal) {
+        String message = "";
+
+        List<String> exercises = new ArrayList<>();
+        StringBuilder messageBuilder = new StringBuilder("오늘은 ");
+
+        List<ExerciseList> exerciseList = exerciseListRepository.findByExerciseJournalId(exerciseJournal.getId())
+                .orElseThrow(NotFoundExerciseList::new);
+
+        for (ExerciseList list : exerciseList) {
+            Long exerciseId = list.getExercise().getId();
+            Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow(NotFoundExercise::new);
+            exercises.add(exercise.getName());
+        }
+
+        for (int i = 0; i < exercises.size(); i++) {
+            messageBuilder.append(exercises.get(i));
+            if (i < exercises.size() - 1) {
+                messageBuilder.append(", ");
+            }
+        }
+        messageBuilder.append(" 하는 날입니다.");
+        message = messageBuilder.toString();
+
+        return message;
+    }
+
+    public void sendNotification(NotificationRequestDto requestDto) throws ExecutionException, InterruptedException {
+        Message message = Message.builder()
+                .setWebpushConfig(WebpushConfig.builder()
+                        .setNotification(WebpushNotification.builder()
+                                .setTitle(requestDto.getTitle())
+                                .setBody(requestDto.getMessage())
+                                .build())
+                        .build())
+                .setToken(requestDto.getToken())
+                .build();
+
+        String response = FirebaseMessaging.getInstance().sendAsync(message).get();
+        log.info("Send message : " + response);
+    }
+
+
+    public void deleteFcmToken(OAuth2JwtUserDetails oAuth2JwtUserDetails, FcmTokenRequestDto fcmTokenRequestDto) {
+        User user = userHelper.findUserByEmail(oAuth2JwtUserDetails.getEmail());
+        String token = fcmTokenRequestDto.getToken();
+
+        FcmToken fcmToken = fcmTokenRepository.findByUserAndToken(user, token).orElseThrow(NotFoundFcmToken::new);
+        fcmTokenRepository.delete(fcmToken);
+    }
+
+}

--- a/src/main/java/com/ogjg/daitgym/alarm/service/ScheduledService.java
+++ b/src/main/java/com/ogjg/daitgym/alarm/service/ScheduledService.java
@@ -1,0 +1,58 @@
+package com.ogjg.daitgym.alarm.service;
+
+import com.ogjg.daitgym.alarm.dto.NotificationRequestDto;
+import com.ogjg.daitgym.alarm.repository.FcmTokenRepository;
+import com.ogjg.daitgym.comment.feedExerciseJournal.exception.NotFoundExerciseJournal;
+import com.ogjg.daitgym.domain.FcmToken;
+import com.ogjg.daitgym.domain.User;
+import com.ogjg.daitgym.domain.journal.ExerciseJournal;
+import com.ogjg.daitgym.journal.repository.journal.ExerciseJournalRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScheduledService {
+
+    private final FcmAlarmService notificationService;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final ExerciseJournalRepository exerciseJournalRepository;
+
+
+    /**
+     * 7시 30분에 알림 메세지 보내기
+     */
+    @Scheduled(cron = "0 0 15 * * *")
+    public void scheduledSend() throws ExecutionException, InterruptedException {
+
+        List<FcmToken> fcmTokens = fcmTokenRepository.findAll();
+
+        if (fcmTokens.isEmpty()) {
+            log.info("fcmToken이 없어, 작업을 하지 않습니다.");
+            return;
+        }
+
+        for (FcmToken fcmToken : fcmTokens) {
+            User user = fcmToken.getUser();
+            ExerciseJournal exerciseJournal = exerciseJournalRepository.findByUserAndJournalDate(user, LocalDate.now()).orElseThrow(NotFoundExerciseJournal::new);
+
+            String message = notificationService.alarmMessage(exerciseJournal);
+
+            NotificationRequestDto notificationRequestDto = NotificationRequestDto.builder()
+                    .title("[DaItGym 운동 알림]")
+                    .message(message)
+                    .token(fcmToken.getToken())
+                    .build();
+
+            notificationService.sendNotification(notificationRequestDto);
+        }
+        log.info("웹푸시 보냈어!");
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/ErrorCode.java
@@ -53,7 +53,9 @@ public enum ErrorCode implements ErrorType {
     ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "400", "중복되는 닉네임입니다."),
     EMPTY_TRAINER_APPLY_APPROVAL(HttpStatus.BAD_REQUEST, "400", "잘못된 승인 신청입니다. 자격 혹은 수상내역 입력이 누락되었습니다."),
     ALREADY_SCRAPPED_ROUTINE(HttpStatus.BAD_REQUEST, "400", "이미 스크랩한 루틴입니다."),
-    ALREADY_PROCEEDING_APPROVAL(HttpStatus.BAD_REQUEST, "400", "이미 심사가 진행중입니다."),;
+    ALREADY_PROCEEDING_APPROVAL(HttpStatus.BAD_REQUEST, "400", "이미 심사가 진행중입니다."),
+    NOT_FOUND_FCM_TOKEN(HttpStatus.BAD_REQUEST, "404", "FCM토큰이 존재하지 않습니다"),
+    ;
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/src/main/java/com/ogjg/daitgym/common/exception/fcmtoken/NotFoundFcmToken.java
+++ b/src/main/java/com/ogjg/daitgym/common/exception/fcmtoken/NotFoundFcmToken.java
@@ -1,0 +1,21 @@
+package com.ogjg.daitgym.common.exception.fcmtoken;
+
+import com.ogjg.daitgym.common.exception.CustomException;
+import com.ogjg.daitgym.common.exception.ErrorCode;
+import com.ogjg.daitgym.common.exception.ErrorData;
+
+public class NotFoundFcmToken extends CustomException {
+
+
+    public NotFoundFcmToken() {
+        super(ErrorCode.NOT_FOUND_FCM_TOKEN);
+    }
+
+    public NotFoundFcmToken(String message) {
+        super(ErrorCode.NOT_FOUND_FCM_TOKEN, message);
+    }
+
+    public NotFoundFcmToken(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_FCM_TOKEN, errorData);
+    }
+}

--- a/src/main/java/com/ogjg/daitgym/domain/FcmToken.java
+++ b/src/main/java/com/ogjg/daitgym/domain/FcmToken.java
@@ -1,0 +1,33 @@
+package com.ogjg.daitgym.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class FcmToken {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "email")
+    private User user;
+
+    private String token;
+
+    @Builder
+    public FcmToken(String token, User user) {
+        this.token = token;
+        this.user = user;
+    }
+
+}

--- a/src/main/java/com/ogjg/daitgym/journal/repository/exerciselist/ExerciseListRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/exerciselist/ExerciseListRepository.java
@@ -5,6 +5,7 @@ import com.ogjg.daitgym.domain.journal.ExerciseList;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ExerciseListRepository extends JpaRepository<ExerciseList, Long> {
 
@@ -12,4 +13,5 @@ public interface ExerciseListRepository extends JpaRepository<ExerciseList, Long
 
     void deleteAllByExerciseJournal(ExerciseJournal exerciseJournal);
 
+    Optional<List<ExerciseList>> findByExerciseJournalId(Long exerciseJournalId);
 }

--- a/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
+++ b/src/main/java/com/ogjg/daitgym/journal/repository/journal/ExerciseJournalRepository.java
@@ -17,4 +17,6 @@ public interface ExerciseJournalRepository extends JpaRepository<ExerciseJournal
     int countByUserAndIsCompleted(User user, boolean completed);
 
     int countByUserEmail(String email);
+
+    Optional<ExerciseJournal> findByUserAndJournalDate(User user, LocalDate now);
 }

--- a/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
+++ b/src/main/java/com/ogjg/daitgym/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.ogjg.daitgym.user.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ogjg.daitgym.alarm.dto.FcmTokenRequestDto;
+import com.ogjg.daitgym.alarm.service.FcmAlarmService;
 import com.ogjg.daitgym.common.exception.ErrorCode;
 import com.ogjg.daitgym.common.response.ApiResponse;
 import com.ogjg.daitgym.config.security.details.OAuth2JwtUserDetails;
@@ -27,6 +29,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final FcmAlarmService fcmAlarmService;
 
     private final ObjectMapper objectMapper;
 
@@ -34,8 +37,11 @@ public class UserController {
      * 로그아웃 - 메시지 지정 필요
      */
     @PostMapping("/logout")
-    public ApiResponse<?> logout(HttpServletResponse response) {
+    public ApiResponse<?> logout(HttpServletResponse response,
+                                 @AuthenticationPrincipal OAuth2JwtUserDetails oAuth2JwtUserDetails,
+                                 @RequestBody FcmTokenRequestDto fcmTokenRequestDto) {
         response.setHeader("Set-Cookie", userService.getExpiredResponseCookie().toString());
+        fcmAlarmService.deleteFcmToken(oAuth2JwtUserDetails, fcmTokenRequestDto);
         return new ApiResponse<>(ErrorCode.SUCCESS.changeMessage("로그아웃 성공"));
     }
 


### PR DESCRIPTION
- build.gradle : FCM 푸시를 위한 의존성 추가
- 로그인 시, fcm 토큰을 발급받고 fcmRepository에 fcm토큰이 없을 경우에만 저장
- 지정된 시간에 미리 작성된 운동일지의 운동에 대한 알림을 보냄 ex) 오늘은 푸쉬업, 어시스트 풀업 머신 하는 날입니다.
    - 내일(24일 금요일) 오후 3시에 테스트해보기 위해 3시로 설정해놓음 
    - 추후 오전 7시30분으로 수정할 예정
- 로그아웃 시, 유저정보를 받아와 저장된 fcm 토큰을 삭제함
